### PR TITLE
release: CHANGELOG, docs audit, and v1.0.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,160 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-02-20
+
+Initial public release of `openclaw-go`, a Go client library for the
+[OpenClaw](https://openclaw.ai) AI gateway.
+
+Single external dependency: [gorilla/websocket v1.5.3](https://github.com/gorilla/websocket).
+All library packages target 100% statement coverage and pass the Go race detector.
+
+### Added
+
+#### `protocol` — Gateway Wire Types
+
+- Complete set of Go types for the OpenClaw Gateway WebSocket protocol (v3)
+- Frame types: `Request`, `Response`, `Event`, `Invoke`, `InvokeResponse`
+- Handshake types: `ConnectChallenge`, `ConnectParams`, `HelloOK`, `Snapshot`, `HelloPolicy`
+- All role and scope constants: `RoleOperator`, `RoleNode`, `ScopeOperatorRead`, `ScopeOperatorWrite`, `ScopeOperatorAdmin`, `ScopeOperatorApprovals`, `ScopeOperatorPairing`
+- Chat types: `ChatSendParams`, `ChatHistoryParams`, `ChatAbortParams`, `ChatInjectParams`, `ChatEvent`
+- Agent types: `AgentParams`, `AgentWaitParams`, `AgentIdentityParams`, `AgentEvent`
+- Session types: `SessionsListParams`, `SessionsPreviewParams`, `SessionsPatchParams`, `SessionsResetParams`, `SessionsDeleteParams`, `SessionsUsageParams`, `SessionsCompactParams`, `SessionsResolveParams`
+- Agents CRUD types: `AgentsCreateParams/Result`, `AgentsUpdateParams/Result`, `AgentsDeleteParams/Result`, `AgentsFilesListResult`, `AgentsFilesGetParams/Result`, `AgentsFilesSetParams/Result`
+- Exec approval types: `ExecApprovalRequestParams/Result`, `ExecApprovalResolveParams/Result`, `ExecApprovalWaitDecisionParams/Result`, `ExecApprovalsSnapshot`, `ExecApprovalsFile`
+- Config types: `ConfigGetParams`, `ConfigSetParams`, `ConfigPatchParams`, `ConfigApplyParams`, `ConfigSchemaResponse`
+- Node types: `NodePairRequestParams`, `NodePairApproveParams`, `NodePairRejectParams`, `NodePairVerifyParams`, `NodeDescribeParams`, `NodeInvokeParams`, `NodeInvokeResultParams`, `NodeEventParams`
+- Device pairing types: `DevicePairApproveParams`, `DevicePairRejectParams`, `DevicePairRemoveParams`, `DeviceTokenRotateParams`, `DeviceTokenRevokeParams`
+- Cron types: `CronAddParams`, `CronUpdateParams`, `CronRemoveParams`, `CronRunParams`, `CronRunsParams`, `CronJob`, `CronRunLogEntry`, `CronSchedule`, `CronPayload`
+- TTS types: `TTSConvertParams/Result`, `TTSSetProviderParams/Result`, `TTSStatusResult`, `TTSProvidersResult`, `TTSEnableResult`, `TTSDisableResult`
+- Channel and talk types: `ChannelsStatusParams/Result`, `TalkModeParams`, `TalkConfigParams/Result`
+- Skills types: `SkillsStatusParams`, `SkillsBinsResult`, `SkillsInstallParams`, `SkillsUpdateParams`
+- Wizard types: `WizardStartParams/Result`, `WizardNextParams/Result`, `WizardCancelParams`, `WizardStatusParams/Result`, `WizardStep`
+- Misc types: `SendParams`, `WakeParams`, `PollParams`, `PushTestParams/Result`, `PresenceEntry`, `ModelsListResult`, `LogsTailParams/Result`
+- Serialization helpers: `MarshalEvent`, `MarshalResponse`, `MarshalErrorResponse`, `ParseFrame`
+- Server constants: `ProtocolVersion` (3), `MaxPayloadBytes`, `MaxBufferedBytes`, `DefaultTickIntervalMs`, `DedupeTTLMs`, `SessionLabelMaxLength`
+- Client ID and mode constants for all first-party clients
+
+#### `gateway` — WebSocket Gateway Client
+
+- `Client` struct with full connection lifecycle: challenge→connect→hello-ok handshake
+- Background read loop with frame dispatch (requests, events, invocations)
+- Keepalive tick loop using the gateway's `TickIntervalMs` policy
+- Pending request/response correlation with atomic request ID counter
+- Functional options: `WithToken`, `WithPassword`, `WithRole`, `WithScopes`, `WithCaps`, `WithCommands`, `WithPermissions`, `WithDevice`, `WithLocale`, `WithUserAgent`, `WithTLSConfig`, `WithConnectTimeout`, `WithOnEvent`, `WithOnInvoke`, `WithClientInfo`
+- `Connect(ctx, wsURL)` — connects and completes the handshake
+- `Close()` — graceful shutdown; `Done()` channel signals completion
+- `Hello()` — returns the `HelloOK` payload from the server
+- `Send(ctx, method, params)` — low-level typed RPC send
+- `SendEvent(eventName, payload)` — send a uni-directional event frame
+- **96+ typed RPC methods**, organized by domain:
+  - Chat: `ChatSend`, `ChatHistory`, `ChatAbort`, `ChatInject`
+  - Agent: `Agent`, `AgentIdentity`, `AgentWait`
+  - Sessions: `SessionsList`, `SessionsPreview`, `SessionsResolve`, `SessionsPatch`, `SessionsReset`, `SessionsDelete`, `SessionsCompact`, `SessionsUsage`
+  - Agents CRUD: `AgentsList`, `AgentsCreate`, `AgentsUpdate`, `AgentsDelete`, `AgentsFilesList`, `AgentsFilesGet`, `AgentsFilesSet`
+  - Config: `ConfigGet`, `ConfigSet`, `ConfigPatch`, `ConfigApply`, `ConfigSchema`
+  - Exec approvals: `ExecApprovalRequest`, `ExecApprovalResolve`, `ExecApprovalWaitDecision`, `ExecApprovalsGet`, `ExecApprovalsSet`, `ExecApprovalsNodeGet`, `ExecApprovalsNodeSet`
+  - Nodes: `NodeList`, `NodeDescribe`, `NodeInvoke`, `NodeInvokeResult`, `NodeEvent`, `NodeRename`
+  - Node pairing: `NodePairRequest`, `NodePairList`, `NodePairApprove`, `NodePairReject`, `NodePairVerify`
+  - Device pairing: `DevicePairList`, `DevicePairApprove`, `DevicePairReject`, `DevicePairRemove`, `DeviceTokenRotate`, `DeviceTokenRevoke`
+  - Cron: `CronList`, `CronStatus`, `CronAdd`, `CronUpdate`, `CronRemove`, `CronRun`, `CronRuns`
+  - TTS: `TTSStatus`, `TTSProviders`, `TTSEnable`, `TTSDisable`, `TTSConvert`, `TTSSetProvider`
+  - Channels: `ChannelsStatus`, `ChannelsLogout`, `TalkConfig`, `TalkMode`
+  - Models: `ModelsList`
+  - Logs: `LogsTail`
+  - Skills: `SkillsStatus`, `SkillsBins`, `SkillsInstall`, `SkillsUpdate`
+  - Wizard: `WizardStart`, `WizardNext`, `WizardCancel`, `WizardStatus`
+  - Presence: `Presence`
+  - Misc: `Health`, `Status`, `SendMessage`, `Wake`, `LastHeartbeat`, `SetHeartbeats`, `SystemEvent`, `UpdateRun`, `PushTest`, `BrowserRequest`, `VoiceWakeGet`, `VoiceWakeSet`, `UsageStatus`, `UsageCost`, `Poll`
+- Concurrent-safe: mutex-protected writes, atomic request counters, synchronized pending-response map
+
+#### `chatcompletions` — OpenAI-compatible Chat Completions Client
+
+- `Client` struct with `BaseURL`, `Token`, `AgentID`, `SessionKey`, `HTTPClient` fields
+- `Create(ctx, Request) (*Response, error)` — non-streaming chat completion
+- `CreateStream(ctx, Request) (*Stream, error)` — server-sent events streaming completion
+- `Stream.Recv() (*Chunk, error)` — read next SSE chunk; returns `io.EOF` at end
+- `Stream.Close()` — close the underlying HTTP response body
+- Request type with `Model`, `Messages`, `MaxTokens`, `Temperature`, `Stream` fields
+- Response type with `Choices`, `Usage` (prompt/completion/total tokens), `Model`, `ID`
+- Streaming chunk type with `Choices[].Delta.Content`
+- `Authorization: Bearer` token header support
+- `x-openclaw-agent-id` and `x-openclaw-session-key` custom header support
+
+#### `openresponses` — OpenAI Responses API Client
+
+- `Client` struct with `BaseURL`, `Token`, `AgentID`, `SessionKey`, `HTTPClient` fields
+- `Create(ctx, Request) (*Response, error)` — non-streaming responses request
+- `CreateStream(ctx, Request) (*Stream, error)` — SSE streaming with typed events
+- `Stream.Recv() (*StreamEvent, error)` — read next typed SSE event; returns `io.EOF` at end
+- `Stream.Close()` — close the underlying HTTP response body
+- `InputFromItems([]InputItem) Input` — helper to build structured input
+- `MessageItem(role, text string) InputItem` — helper to build a text message item
+- Structured input items: text messages, images, audio, resource links, function call outputs
+- Tool definitions: `ToolDefinition` with `FunctionTool` (name, description, parameters schema)
+- Response type with `Output` items, `Usage` (input/output/total tokens), `Status`, `ID`
+- Typed SSE event types: `response.created`, `response.output_text.delta`, `response.output_text.done`, `response.function_call_arguments.delta`, `response.completed`, and more
+- `Authorization: Bearer` token, `x-openclaw-agent-id`, `x-openclaw-session-key` header support
+
+#### `toolsinvoke` — Tools Invoke HTTP Client
+
+- `Client` struct with `BaseURL`, `Token`, `MessageChannel`, `AccountID`, `HTTPClient` fields
+- `Invoke(ctx, Request) (*Response, error)` — calls `POST /tools/invoke`
+- Request type with `Tool`, `Action`, `Args`, `SessionKey`, `DryRun` fields
+- Response type with `OK`, `Result` (`json.RawMessage`), `Error` (`*ErrorDetail`)
+- `ErrorDetail` with `Type` and `Message` fields
+- `Authorization: Bearer` token, `x-openclaw-message-channel`, `x-openclaw-account-id` header support
+
+#### `discovery` — mDNS/DNS-SD Gateway Discovery
+
+- `Browser` struct for discovering OpenClaw Gateway instances on the local network
+- `NewBrowser() *Browser` — create a new browser
+- `Browser.Browse(ctx) ([]Beacon, error)` — scan for gateways, returns after context deadline
+- `Beacon` struct with all mDNS TXT record fields: `Host`, `Port`, `DisplayName`, `LanHost`, `TailnetDNS`, `GatewayPort`, `GatewayTLS`, `GatewayTLSFingerprint`, `SSHPort`, `CLIPath`, `Role`, `CanvasPort`
+- `Beacon.WebSocketURL() string` — derives `ws://` or `wss://` URL with host priority: SRV host → TailnetDNS → LanHost → `127.0.0.1`
+- `Beacon.HTTPURL() string` — derives `http://` or `https://` base URL
+- macOS implementation via `dns-sd -B` / `dns-sd -L` (Bonjour)
+- Linux implementation via `avahi-browse`
+- Windows: returns an informative `not supported` error
+- `ServiceType` constant: `_openclaw-gw._tcp`
+
+#### `acp` — Agent Client Protocol Server
+
+- `Server` struct for handling ACP (Agent Client Protocol) over stdio
+- `NewServer(handler Handler, r io.Reader, w io.Writer) *Server` — create a new ACP server
+- `Server.Serve(ctx) error` — run the JSON-RPC 2.0 / NDJSON dispatch loop
+- `Server.Notify(method string, params any) error` — send a server-initiated notification
+- `Handler` interface with all ACP methods:
+  - `Initialize`, `Authenticate`
+  - `NewSession`, `LoadSession`, `ListSessions`, `ForkSession`, `ResumeSession`
+  - `Prompt`, `Cancel`
+  - `SetSessionMode`, `SetSessionModel`, `SetSessionConfigOption`
+- Full ACP type coverage: `InitializeRequest/Response`, `AuthenticateRequest/Response`, `NewSessionRequest/Response`, `LoadSessionRequest/Response`, `ListSessionsRequest/Response`, `ForkSessionRequest/Response`, `ResumeSessionRequest/Response`, `PromptRequest/Response`, `CancelNotification`, `SetSessionModeRequest/Response`, `SetSessionModelRequest/Response`, `SetSessionConfigOptionRequest/Response`
+- `AgentCapabilities` with `LoadSession`, `PromptCapabilities` (image, embedded context), `SessionCapabilities` (list, fork, resume)
+- Session update notification support via `Notify`
+- `ProtocolVersion` constant: `1`
+- Standard and extended JSON-RPC 2.0 error codes
+
+#### Examples
+
+Twelve runnable examples in `examples/`:
+
+- `server` — mock OpenClaw Gateway for local development (WebSocket + HTTP)
+- `client` — demonstrates all three APIs: WebSocket, Chat Completions, Tools Invoke
+- `chat` — interactive chat session with streaming event handling
+- `openresponses` — OpenAI Responses API with tool definitions and SSE streaming
+- `agents` — agent CRUD: list, create, update, files, delete
+- `sessions` — session management: list, preview, patch, usage, reset
+- `approvals` — exec approval flow: listen for events, approve/reject, admin config
+- `pairing` — node and device pairing workflows
+- `config` — gateway configuration: get, schema, patch, apply
+- `cron` — cron job management: list, add, run, history, remove
+- `node` — connect as a node: declare capabilities, handle invocations, send events
+- `discovery` — scan the LAN for OpenClaw gateways via mDNS
+- `acp` — ACP agent server implementation over stdio
+
+[1.0.0]: https://github.com/a3tai/openclaw-go/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,3 +92,66 @@ go build ./examples/...
 
 By contributing, you agree that your contributions will be licensed under the
 MIT License. See [LICENSE](LICENSE).
+
+## Releasing
+
+This section is for maintainers with push access to the repository.
+
+### How to Cut a Release
+
+1. **Ensure everything is green**
+
+   ```bash
+   go test ./... -race
+   go vet ./...
+   go build ./...
+   go build ./examples/...
+   go mod tidy
+   ```
+
+   All tests must pass with the race detector enabled. There should be no
+   uncommitted changes after `go mod tidy`.
+
+2. **Update CHANGELOG.md**
+
+   Add a new version section following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+   format. Move items from `[Unreleased]` if present, or document the changes
+   under the appropriate headings (`Added`, `Changed`, `Deprecated`, `Removed`,
+   `Fixed`, `Security`).
+
+3. **Commit and tag**
+
+   ```bash
+   git add CHANGELOG.md
+   git commit -s -m "release: vX.Y.Z"
+   git tag vX.Y.Z
+   git push origin main --tags
+   ```
+
+4. **Create the GitHub release**
+
+   ```bash
+   gh release create vX.Y.Z \
+     --title "vX.Y.Z" \
+     --notes "$(awk '/^## \[X.Y.Z\]/,/^## \[/' CHANGELOG.md | head -n -1)" \
+     --repo a3tai/openclaw-go
+   ```
+
+   Or use the GitHub UI: go to **Releases → Draft a new release**, select the
+   tag, paste the CHANGELOG section as release notes, and publish.
+
+### Semantic Versioning Commitment (post-1.0.0)
+
+This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+strictly from v1.0.0 onward:
+
+- **Patch** (`vX.Y.Z+1`): backwards-compatible bug fixes only. No new exported
+  symbols, no signature changes.
+- **Minor** (`vX.Y+1.0`): new backwards-compatible functionality. New exported
+  functions, types, or methods. Existing callers are unaffected.
+- **Major** (`vX+1.0.0`): breaking changes to the public API. This requires a
+  module path change (e.g., `github.com/a3tai/openclaw-go/v2`) per Go module
+  conventions. Breaking changes should be rare and discussed in issues first.
+
+When in doubt, bump minor rather than major — adding is non-breaking, changing
+or removing is breaking.

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -75,7 +75,7 @@ result, err := client.ChatSend(ctx, protocol.ChatSendParams{
 })
 history, err := client.ChatHistory(ctx, protocol.ChatHistoryParams{SessionKey: "main"})
 err := client.ChatAbort(ctx, protocol.ChatAbortParams{SessionKey: "main"})
-err := client.ChatInject(ctx, protocol.ChatInjectParams{SessionKey: "main", Messages: msgs})
+err := client.ChatInject(ctx, protocol.ChatInjectParams{SessionKey: "main", Message: "system note"})
 ```
 
 ### Agent
@@ -90,11 +90,11 @@ result, err := client.AgentWait(ctx, protocol.AgentWaitParams{})
 
 ```go
 sessions, err := client.SessionsList(ctx, protocol.SessionsListParams{})
-preview, err := client.SessionsPreview(ctx, protocol.SessionsPreviewParams{SessionKey: key})
-err := client.SessionsPatch(ctx, protocol.SessionsPatchParams{SessionKey: key, Label: &label})
-usage, err := client.SessionsUsage(ctx, protocol.SessionsUsageParams{SessionKey: key})
-err := client.SessionsReset(ctx, protocol.SessionsResetParams{SessionKey: key})
-err := client.SessionsDelete(ctx, protocol.SessionsDeleteParams{SessionKey: key})
+preview, err := client.SessionsPreview(ctx, protocol.SessionsPreviewParams{Keys: []string{key}})
+err := client.SessionsPatch(ctx, protocol.SessionsPatchParams{Key: key, Label: &label})
+usage, err := client.SessionsUsage(ctx, protocol.SessionsUsageParams{Key: key})
+err := client.SessionsReset(ctx, protocol.SessionsResetParams{Key: key})
+err := client.SessionsDelete(ctx, protocol.SessionsDeleteParams{Key: key})
 ```
 
 ### Agents CRUD
@@ -103,22 +103,22 @@ err := client.SessionsDelete(ctx, protocol.SessionsDeleteParams{SessionKey: key}
 list, err := client.AgentsList(ctx)
 created, err := client.AgentsCreate(ctx, protocol.AgentsCreateParams{Name: "my-agent"})
 err := client.AgentsUpdate(ctx, protocol.AgentsUpdateParams{AgentID: id})
-err := client.AgentsDelete(ctx, protocol.AgentsDeleteParams{AgentID: id})
+deleted, err := client.AgentsDelete(ctx, protocol.AgentsDeleteParams{AgentID: id})
 
 // Agent files
 files, err := client.AgentsFilesList(ctx, protocol.AgentsFilesListParams{AgentID: id})
-content, err := client.AgentsFilesGet(ctx, protocol.AgentsFilesGetParams{AgentID: id, Path: path})
-err := client.AgentsFilesSet(ctx, protocol.AgentsFilesSetParams{AgentID: id, Path: path, Content: data})
+file, err := client.AgentsFilesGet(ctx, protocol.AgentsFilesGetParams{AgentID: id, Name: name})
+setResult, err := client.AgentsFilesSet(ctx, protocol.AgentsFilesSetParams{AgentID: id, Name: name, Content: data})
 ```
 
 ### Config
 
 ```go
-cfg, err := client.ConfigGet(ctx, protocol.ConfigGetParams{})
+cfg, err := client.ConfigGet(ctx)
 schema, err := client.ConfigSchema(ctx)
-err := client.ConfigSet(ctx, protocol.ConfigSetParams{Key: "key", Value: val})
-err := client.ConfigPatch(ctx, protocol.ConfigPatchParams{Patch: patch})
-err := client.ConfigApply(ctx, protocol.ConfigApplyParams{Restart: true})
+err := client.ConfigSet(ctx, protocol.ConfigSetParams{Raw: raw})
+err := client.ConfigPatch(ctx, protocol.ConfigPatchParams{Raw: raw})
+err := client.ConfigApply(ctx, protocol.ConfigApplyParams{Raw: raw, RestartDelayMs: &ms})
 ```
 
 ### Exec Approvals
@@ -137,17 +137,17 @@ result, err := client.ExecApprovalWaitDecision(ctx, protocol.ExecApprovalWaitDec
 // Node operations
 result, err := client.NodeList(ctx)
 desc, err := client.NodeDescribe(ctx, protocol.NodeDescribeParams{NodeID: id})
-result, err := client.NodeInvoke(ctx, protocol.NodeInvokeParams{NodeID: id, Cap: "tool", Args: args})
+result, err := client.NodeInvoke(ctx, protocol.NodeInvokeParams{NodeID: id, Command: cmd, Params: params, IdempotencyKey: key})
 
 // Node pairing
 result, err := client.NodePairRequest(ctx, protocol.NodePairRequestParams{...})
 pairs, err := client.NodePairList(ctx)
-err := client.NodePairApprove(ctx, protocol.NodePairApproveParams{ID: id})
-err := client.NodePairReject(ctx, protocol.NodePairRejectParams{ID: id})
+err := client.NodePairApprove(ctx, protocol.NodePairApproveParams{RequestID: id})
+err := client.NodePairReject(ctx, protocol.NodePairRejectParams{RequestID: id})
 
 // Device pairing
 pairs, err := client.DevicePairList(ctx)
-err := client.DevicePairApprove(ctx, protocol.DevicePairApproveParams{ID: id})
+err := client.DevicePairApprove(ctx, protocol.DevicePairApproveParams{RequestID: id})
 err := client.DevicePairRemove(ctx, protocol.DevicePairRemoveParams{DeviceID: id})
 result, err := client.DeviceTokenRotate(ctx, protocol.DeviceTokenRotateParams{DeviceID: id})
 ```
@@ -157,11 +157,11 @@ result, err := client.DeviceTokenRotate(ctx, protocol.DeviceTokenRotateParams{De
 ```go
 jobs, err := client.CronList(ctx, protocol.CronListParams{})
 status, err := client.CronStatus(ctx)
-err := client.CronAdd(ctx, protocol.CronAddParams{Name: "nightly", Schedule: sched})
-err := client.CronUpdate(ctx, protocol.CronUpdateParams{ID: id})
-err := client.CronRemove(ctx, protocol.CronRemoveParams{ID: id})
-err := client.CronRun(ctx, protocol.CronRunParams{ID: id})
-runs, err := client.CronRuns(ctx, protocol.CronRunsParams{ID: id})
+result, err := client.CronAdd(ctx, protocol.CronAddParams{Name: "nightly", Schedule: sched})
+err := client.CronUpdate(ctx, protocol.CronUpdateParams{JobID: id})
+err := client.CronRemove(ctx, protocol.CronRemoveParams{JobID: id})
+err := client.CronRun(ctx, protocol.CronRunParams{JobID: id})
+runs, err := client.CronRuns(ctx, protocol.CronRunsParams{JobID: id})
 ```
 
 ### TTS
@@ -169,10 +169,10 @@ runs, err := client.CronRuns(ctx, protocol.CronRunsParams{ID: id})
 ```go
 status, err := client.TTSStatus(ctx)
 providers, err := client.TTSProviders(ctx)
-err := client.TTSEnable(ctx)
-err := client.TTSDisable(ctx)
+result, err := client.TTSEnable(ctx)
+result, err := client.TTSDisable(ctx)
 result, err := client.TTSConvert(ctx, protocol.TTSConvertParams{Text: "Hello"})
-err := client.TTSSetProvider(ctx, protocol.TTSSetProviderParams{Provider: "eleven"})
+result, err := client.TTSSetProvider(ctx, protocol.TTSSetProviderParams{Provider: "eleven"})
 ```
 
 ### Other Methods
@@ -217,7 +217,7 @@ client := gateway.NewClient(
     gateway.WithCaps("search", "calculator"),
     gateway.WithOnInvoke(func(inv protocol.Invoke) protocol.InvokeResponse {
         // Handle the invocation
-        result := processInvocation(inv.Cap, inv.Args)
+        result := processInvocation(inv.Command, inv.Params)
         return protocol.InvokeResponse{
             OK:      true,
             Payload: result,

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -91,7 +91,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ChatHistory: %v", err)
 	}
-	fmt.Printf("History entries: %d\n", len(history))
+	fmt.Printf("History response: %d bytes\n", len(history))
 
 	fmt.Println("\n=== Done ===")
 }


### PR DESCRIPTION
## Summary

This PR prepares **openclaw-go v1.0.0** for release by adding a changelog, auditing documentation against the actual implementation, and documenting the release process.

### What's in this PR

#### ✅ CHANGELOG.md (new)

Complete [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) formatted changelog for v1.0.0. Documents:
- All 7 packages and their public APIs
- 96+ typed gateway RPC methods
- Single external dependency (gorilla/websocket v1.5.3)
- 100% statement coverage and race-detector-clean guarantees
- 12 runnable examples

#### 🔧 docs/gateway.md — 12 API corrections

Cross-checked every snippet in the gateway docs against the actual Go source. Fixed the following inaccuracies:

| Section | Issue | Fix |
|---------|-------|-----|
| Sessions | `SessionKey` field used in `SessionsXxxParams` | Renamed to `Key` (actual struct field name) |
| Sessions | `SessionsPreviewParams{SessionKey: key}` | Corrected to `{Keys: []string{key}}` |
| Agents | `AgentsDelete` / `AgentsFilesSet` shown as returning `error` | Both return typed results |
| Agents | `AgentsFilesGetParams{Path: path}` | Field is `Name`, not `Path` |
| Config | `ConfigGet(ctx, protocol.ConfigGetParams{})` | Actual signature takes no params |
| Config | `ConfigSetParams{Key:, Value:}` | Actual struct has `{Raw: raw}` |
| Config | `ConfigPatchParams{Patch: patch}` | Field is `Raw` |
| Config | `ConfigApplyParams{Restart: true}` | Fields are `Raw` + `RestartDelayMs` |
| Cron | `CronAdd` shown as `err := ...` | Returns `(json.RawMessage, error)` |
| Cron | `CronXxxParams{ID: id}` | Field name in examples is `JobID` |
| Pairing | `NodePairApproveParams{ID: id}` | Field is `RequestID` |
| Pairing | `DevicePairApproveParams{ID: id}` | Field is `RequestID` |
| Node mode | `inv.Cap` / `inv.Args` | Should be `inv.Command` / `inv.Params` |
| TTS | `TTSEnable/Disable/SetProvider` shown as returning `error` | All return typed results |

#### 🔧 examples/chat/main.go

Clarified that `ChatHistory` returns `json.RawMessage` (a byte slice), so `len(history)` gives the byte count, not the number of history entries. Updated the print statement to reflect this.

#### 📝 CONTRIBUTING.md — Releasing section (new)

Added a **Releasing** section explaining:
- The full release checklist (tests, vet, build, mod tidy)
- How to tag and create a GitHub release with `gh release create`
- Semantic versioning commitment for post-1.0.0: what constitutes patch/minor/major

### Verification

- `go build ./...` ✅
- `go build ./examples/...` ✅
- `go test ./... -race` ✅ (all packages pass)
- `go vet ./...` ✅