### PR TITLE
ci: upgrade codecov-action to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,13 @@ jobs:
       - name: Test with race detector and coverage
         run: go test ./... -race -coverprofile=coverage.out -covermode=atomic
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
           flags: unittests
           fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Build
         run: go build ./...


### PR DESCRIPTION
Updates the Codecov upload step from `@v4` to `@v5`. In v5, the token is passed via `with.token` instead of `env.CODECOV_TOKEN`. Keeps `files`, `flags`, and `fail_ci_if_error` unchanged.