### PR TITLE
fix(gateway): dispatch onEvent asynchronously to unblock readLoop

### DIFF
--- a/gateway/client.go
+++ b/gateway/client.go
@@ -337,7 +337,12 @@ func (c *Client) readLoop() {
 		case protocol.FrameTypeEvent:
 			var ev protocol.Event
 			if json.Unmarshal(msg, &ev) == nil && c.opts.onEvent != nil {
-				c.opts.onEvent(ev)
+				// Dispatch asynchronously so the readLoop never blocks on
+				// a slow event handler (e.g. manager's handleGatewayEvent
+				// acquiring locks or writing to a buffered channel). Blocking
+				// here would stall all WebSocket reads, causing stream
+				// deltas and finals to queue up behind slow handlers.
+				go c.opts.onEvent(ev)
 			}
 
 		case protocol.FrameTypeRequest:


### PR DESCRIPTION
## Summary
- Dispatches the `onEvent` callback in a goroutine instead of calling it synchronously in the `readLoop`
- Prevents slow event handlers (lock contention, buffered channel writes) from blocking WebSocket frame reads
- Fixes streaming issues in the desktop app where deltas and finals pile up behind a stalled handler

## Problem
The `readLoop` goroutine calls `c.opts.onEvent(ev)` synchronously for every incoming event frame. In the desktop app, `handleGatewayEvent` acquires a mutex, unmarshals JSON, strips metadata, and writes to a buffered channel -- all of which can introduce latency. While any of those operations blocks, no further WebSocket frames can be read, causing:
- Streaming deltas to queue up at the OS socket level
- Final events to arrive late (message appears to freeze then pop in all at once)
- In extreme cases, messages never appearing until the handler catches up

## Fix
Wrap the callback in `go c.opts.onEvent(ev)` so each event is dispatched to its own goroutine. The readLoop stays responsive to incoming frames at all times. The desktop gateway manager already handles thread safety internally (mutex-protected state, buffered channels with non-blocking sends), so concurrent handler invocations are safe.