### PR TITLE
test: add edgecase coverage for gateway/protocol/openresponses

### DIFF
--- a/gateway/client_test.go
+++ b/gateway/client_test.go
@@ -1002,6 +1002,58 @@ func TestReadLoopEventNoHandler(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 }
 
+// --- readLoop: event handler is async (slow handler doesn't block) ---
+
+func TestReadLoopEventAsync(t *testing.T) {
+	mg, wsURL, cleanup := startMockGateway(t)
+	defer cleanup()
+
+	slowBlock := make(chan struct{})
+	fastSeen := make(chan struct{})
+
+	client := NewClient(
+		WithToken("tok"),
+		WithConnectTimeout(5*time.Second),
+		WithOnEvent(func(ev protocol.Event) {
+			switch ev.EventName {
+			case "slow":
+				<-slowBlock
+			case "fast":
+				select {
+				case <-fastSeen:
+				default:
+					close(fastSeen)
+				}
+			}
+		}),
+	)
+	defer client.Close()
+	defer close(slowBlock)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := client.Connect(ctx, wsURL); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	mg.waitReady(t)
+	mg.mu.Lock()
+	conn := mg.conns[len(mg.conns)-1]
+	mg.mu.Unlock()
+
+	slowData, _ := protocol.MarshalEvent("slow", map[string]string{})
+	fastData, _ := protocol.MarshalEvent("fast", map[string]string{})
+	conn.WriteMessage(websocket.TextMessage, slowData)
+	conn.WriteMessage(websocket.TextMessage, fastData)
+
+	select {
+	case <-fastSeen:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fast event not handled while slow handler blocked")
+	}
+}
+
 // --- readLoop: invoke without onInvoke handler (no panic) ---
 
 func TestReadLoopInvokeNoHandler(t *testing.T) {

--- a/openresponses/client_test.go
+++ b/openresponses/client_test.go
@@ -121,6 +121,28 @@ func TestCreateWithItems(t *testing.T) {
 	}
 }
 
+func TestCreateMetadataStripping(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if strings.Contains(string(body), "\"metadata\"") {
+			t.Errorf("metadata should be omitted when empty: %s", string(body))
+		}
+		resp := Response{ID: "resp_meta", Object: "response", Status: "completed"}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	client := &Client{BaseURL: srv.URL, Token: "tok"}
+	_, err := client.Create(context.Background(), Request{
+		Model:    "openclaw",
+		Input:    InputFromString("hi"),
+		Metadata: map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+}
+
 func TestCreateWithToolCall(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := Response{

--- a/protocol/protocol_edgecase_test.go
+++ b/protocol/protocol_edgecase_test.go
@@ -235,6 +235,14 @@ func TestParseFrameWithMissingTypeField(t *testing.T) {
 	}
 }
 
+// TestParseFrameWithNonStringType tests ParseFrame when type is not a string.
+func TestParseFrameWithNonStringType(t *testing.T) {
+	input := `{"type":123}`
+	if _, err := ParseFrame([]byte(input)); err == nil {
+		t.Fatal("expected error for non-string type")
+	}
+}
+
 // TestUnmarshalRequestWithMissingFields tests UnmarshalRequest with minimal data.
 func TestUnmarshalRequestWithMissingFields(t *testing.T) {
 	input := `{"type":"req"}`
@@ -339,5 +347,44 @@ func TestHealthEventWithNilChannels(t *testing.T) {
 
 	if !got.OK {
 		t.Error("ok = false")
+	}
+}
+
+// TestChatEventMessageStringPayload ensures string message payloads round-trip.
+func TestChatEventMessageStringPayload(t *testing.T) {
+	input := `{"runId":"run-1","sessionKey":"main","seq":1,"state":"final","message":"hello","usage":{"promptTokens":1}}`
+	var ev ChatEvent
+	if err := json.Unmarshal([]byte(input), &ev); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	var msg string
+	if err := json.Unmarshal(ev.Message, &msg); err != nil {
+		t.Fatalf("unmarshal message: %v", err)
+	}
+	if msg != "hello" {
+		t.Errorf("message = %q", msg)
+	}
+	var usage map[string]any
+	if err := json.Unmarshal(ev.Usage, &usage); err != nil {
+		t.Fatalf("unmarshal usage: %v", err)
+	}
+	if usage["promptTokens"] != float64(1) {
+		t.Errorf("usage.promptTokens = %v", usage["promptTokens"])
+	}
+}
+
+// TestChatEventMessageObjectPayload ensures object message payloads round-trip.
+func TestChatEventMessageObjectPayload(t *testing.T) {
+	input := `{"runId":"run-2","sessionKey":"main","seq":2,"state":"delta","message":{"role":"assistant","content":"hi"}}`
+	var ev ChatEvent
+	if err := json.Unmarshal([]byte(input), &ev); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	var msg map[string]string
+	if err := json.Unmarshal(ev.Message, &msg); err != nil {
+		t.Fatalf("unmarshal message: %v", err)
+	}
+	if msg["content"] != "hi" {
+		t.Errorf("content = %q", msg["content"])
 	}
 }


### PR DESCRIPTION
Adds targeted unit tests:\n\n- gateway: prove onEvent handlers are async (slow handler doesn't block subsequent events)\n- protocol: ParseFrame rejects non-string type; ChatEvent message/usage payload round-trips for string/object payloads\n- openresponses: ensure empty metadata map is omitted from request JSON\n\nAll green with sandbox caveat: set GOTMPDIR (tmp is noexec).\n\nCommands:\n- go test ./...\n- go test -race ./...\n- go vet ./...