### PR TITLE
ci(release): automate upstream sync workflow and release gates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Release and automation policy owners
+.github/workflows/* @slantview
+docs/specs/* @slantview
+
+# Public typed API surface
+protocol/* @slantview
+gateway/* @slantview

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+-
+
+## Why
+
+-
+
+## Validation
+
+- [ ] `go test ./... -race`
+
+## Release Review Gates (required for release-sync PRs)
+
+- [ ] Architecture review
+- [ ] Go standards code review
+- [ ] API coverage review
+- [ ] Security review (Kingpin / @slantview)
+- [ ] Final HITL review
+
+## Notes
+
+-

--- a/.github/workflows/check-upstream-releases.yml
+++ b/.github/workflows/check-upstream-releases.yml
@@ -2,9 +2,8 @@ name: Check Upstream Releases
 
 on:
   schedule:
-    # Run every 6 hours: midnight, 6am, noon, 6pm UTC
     - cron: '0 0,6,12,18 * * *'
-  workflow_dispatch: # Allow manual triggers
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -14,102 +13,103 @@ jobs:
   check-releases:
     name: Check for new openclaw releases
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v4
+      - name: Create tracking issues for untracked upstream releases
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const maxReleasesToScan = 10;
+            const repoOwner = context.repo.owner;
+            const repoName = context.repo.repo;
 
-      - name: Get latest upstream release
-        id: upstream
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Fetch latest non-prerelease from openclaw/openclaw
-          LATEST=$(gh api repos/openclaw/openclaw/releases/latest --jq '.tag_name')
-          echo "version=${LATEST}" >> "$GITHUB_OUTPUT"
-          echo "Latest upstream release: ${LATEST}"
+            const releases = await github.paginate(
+              github.rest.repos.listReleases,
+              {
+                owner: "openclaw",
+                repo: "openclaw",
+                per_page: 100,
+              },
+            );
 
-      - name: Check if we already track this release
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="${{ steps.upstream.outputs.version }}"
+            const stable = releases
+              .filter((r) => !r.draft && !r.prerelease)
+              .slice(0, maxReleasesToScan);
 
-          # Check if an issue already exists for this version
-          EXISTING=$(gh issue list \
-            --repo "${{ github.repository }}" \
-            --label "upstream-release" \
-            --search "in:title ${VERSION}" \
-            --state all \
-            --json number \
-            --jq 'length')
+            core.info(`Scanned ${stable.length} upstream stable releases.`);
 
-          if [ "$EXISTING" -gt 0 ]; then
-            echo "Issue already exists for ${VERSION}, skipping."
-            echo "needed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "No existing issue for ${VERSION}, will create one."
-            echo "needed=true" >> "$GITHUB_OUTPUT"
-          fi
+            try {
+              await github.rest.issues.createLabel({
+                owner: repoOwner,
+                repo: repoName,
+                name: "upstream-release",
+                color: "0E8A16",
+                description: "Tracks new openclaw upstream releases",
+              });
+            } catch (err) {
+              if (err.status !== 422) {
+                throw err;
+              }
+            }
 
-      - name: Fetch release details
-        if: steps.check.outputs.needed == 'true'
-        id: details
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="${{ steps.upstream.outputs.version }}"
+            const existing = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                owner: repoOwner,
+                repo: repoName,
+                state: "all",
+                labels: "upstream-release",
+                per_page: 100,
+              },
+            );
 
-          # Get the release body (changelog)
-          BODY=$(gh api "repos/openclaw/openclaw/releases/tags/${VERSION}" --jq '.body' | head -100)
+            const existingTitles = new Set(existing.map((i) => i.title));
+            let created = 0;
 
-          # Save to file to avoid shell escaping issues
-          echo "${BODY}" > /tmp/release-body.txt
+            for (const release of stable) {
+              const version = release.tag_name;
+              const issueTitle = `Upstream release: openclaw ${version}`;
+              if (existingTitles.has(issueTitle)) {
+                core.info(`Already tracked: ${version}`);
+                continue;
+              }
 
-          # Extract key items that might need Go client changes
-          # Look for new RPC methods, breaking changes, new params
-          echo "## Release Notes (first 100 lines)" > /tmp/issue-body.md
-          echo "" >> /tmp/issue-body.md
-          echo "Upstream version: \`${VERSION}\`" >> /tmp/issue-body.md
-          echo "Release URL: https://github.com/openclaw/openclaw/releases/tag/${VERSION}" >> /tmp/issue-body.md
-          echo "" >> /tmp/issue-body.md
-          echo "### Changelog excerpt" >> /tmp/issue-body.md
-          echo '```' >> /tmp/issue-body.md
-          cat /tmp/release-body.txt >> /tmp/issue-body.md
-          echo '```' >> /tmp/issue-body.md
-          echo "" >> /tmp/issue-body.md
-          echo "### Action items" >> /tmp/issue-body.md
-          echo "" >> /tmp/issue-body.md
-          echo "- [ ] Review changelog for new RPC methods" >> /tmp/issue-body.md
-          echo "- [ ] Review changelog for breaking changes to existing methods" >> /tmp/issue-body.md
-          echo "- [ ] Review changelog for new protocol types" >> /tmp/issue-body.md
-          echo "- [ ] Update \`protocol/protocol.go\` if new types needed" >> /tmp/issue-body.md
-          echo "- [ ] Update \`gateway/\` if new RPC methods needed" >> /tmp/issue-body.md
-          echo "- [ ] Update \`CHANGELOG.md\`" >> /tmp/issue-body.md
-          echo "- [ ] Run tests: \`go test ./... -race\`" >> /tmp/issue-body.md
-          echo "- [ ] Tag release matching upstream version" >> /tmp/issue-body.md
+              const excerpt = (release.body || "")
+                .split(/\r?\n/)
+                .slice(0, 100)
+                .join("\n");
 
-      - name: Ensure upstream-release label exists
-        if: steps.check.outputs.needed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh label create "upstream-release" \
-            --repo "${{ github.repository }}" \
-            --description "Tracks new openclaw upstream releases" \
-            --color "0E8A16" 2>/dev/null || true
+              const body = [
+                "## Release Notes (first 100 lines)",
+                "",
+                `Upstream version: \`${version}\``,
+                `Release URL: ${release.html_url}`,
+                "",
+                "### Changelog excerpt",
+                "```",
+                excerpt,
+                "```",
+                "",
+                "### Action items",
+                "",
+                "- [ ] Create/update `docs/specs/<version>.md`",
+                "- [ ] Review changelog for new RPC methods/protocol types",
+                "- [ ] Update `protocol/` and `gateway/` typed surfaces as needed",
+                "- [ ] Update tests and run `go test ./... -race`",
+                "- [ ] Complete review gates (architecture, go standards, api, kingpin security, hitl)",
+                "- [ ] Merge PR, tag matching upstream version, and publish release",
+              ].join("\n");
 
-      - name: Create tracking issue
-        if: steps.check.outputs.needed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="${{ steps.upstream.outputs.version }}"
+              await github.rest.issues.create({
+                owner: repoOwner,
+                repo: repoName,
+                title: issueTitle,
+                body,
+                labels: ["upstream-release"],
+              });
 
-          gh issue create \
-            --repo "${{ github.repository }}" \
-            --title "Upstream release: openclaw ${VERSION}" \
-            --body-file /tmp/issue-body.md \
-            --label "upstream-release"
+              existingTitles.add(issueTitle);
+              created += 1;
+              core.info(`Created tracking issue: ${issueTitle}`);
+            }
 
-          echo "Created tracking issue for ${VERSION}"
+            core.info(`Done. Created ${created} issue(s).`);

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -194,3 +194,72 @@ jobs:
           fi
 
           echo "PR description looks good."
+
+  # -----------------------------------------------------------------------
+  # Enforce release review gates for release-sync PRs
+  # -----------------------------------------------------------------------
+  release-gates:
+    name: Release Gates
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Validate release gate checklist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || "";
+            const title = pr.title || "";
+            const labels = new Set((pr.labels || []).map((l) => l.name));
+
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                per_page: 100,
+              },
+            );
+
+            const changedPaths = files.map((f) => f.filename);
+            const hasSpecFile = changedPaths.some((p) => /^docs\/specs\/v\d+\.\d+\.\d+(?:-\d+)?\.md$/.test(p));
+
+            const isReleasePR =
+              labels.has("release-sync") ||
+              labels.has("upstream-release") ||
+              /upstream release|release\s*sync|release:\s*v\d+/i.test(title) ||
+              hasSpecFile;
+
+            if (!isReleasePR) {
+              core.info("Not a release-sync PR; skipping release gate enforcement.");
+              return;
+            }
+
+            const requiredChecks = [
+              { name: "Architecture review", re: /- \[[xX]\]\s+Architecture review/ },
+              { name: "Go standards code review", re: /- \[[xX]\]\s+Go standards code review/ },
+              { name: "API coverage review", re: /- \[[xX]\]\s+API coverage review/ },
+              { name: "Security review \(Kingpin \/ @slantview\)", re: /- \[[xX]\]\s+Security review \(Kingpin \/ @slantview\)/ },
+              { name: "Final HITL review", re: /- \[[xX]\]\s+Final HITL review/ },
+              { name: "go test ./... -race", re: /- \[[xX]\]\s+`go test \.\/\.\.\. -race`/ },
+            ];
+
+            const missing = requiredChecks.filter((c) => !c.re.test(body)).map((c) => c.name);
+            if (!hasSpecFile) {
+              missing.push("docs/specs/<version>.md in PR diff");
+            }
+
+            if (missing.length > 0) {
+              core.setFailed(
+                [
+                  "Release gate validation failed.",
+                  "Missing required items:",
+                  ...missing.map((m) => `- ${m}`),
+                ].join("\n"),
+              );
+            } else {
+              core.info("Release gate validation passed.");
+            }

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,163 @@
+name: Publish Release From Merged PR
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+  issues: write
+
+jobs:
+  publish:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release metadata and validate release gates
+        id: meta
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            const title = pr.title || '';
+            const labels = new Set((pr.labels || []).map((l) => l.name));
+
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                per_page: 100,
+              },
+            );
+            const paths = files.map((f) => f.filename);
+            const specFile = paths.find((p) => /^docs\/specs\/v\d+\.\d+\.\d+(?:-\d+)?\.md$/.test(p));
+
+            const isReleasePR =
+              labels.has('release-sync') ||
+              labels.has('upstream-release') ||
+              /upstream release|release\s*sync|release:\s*v\d+/i.test(title) ||
+              Boolean(specFile);
+
+            if (!isReleasePR) {
+              core.info('Not a release-sync PR. Skipping publish workflow.');
+              core.setOutput('should_publish', 'false');
+              return;
+            }
+
+            const version =
+              (specFile && specFile.match(/v\d+\.\d+\.\d+(?:-\d+)?/)?.[0]) ||
+              (title.match(/v\d+\.\d+\.\d+(?:-\d+)?/)?.[0]);
+
+            if (!version) {
+              core.setFailed('Could not resolve release version from spec file or PR title.');
+              return;
+            }
+
+            const requiredChecks = [
+              /- \[[xX]\]\s+Architecture review/,
+              /- \[[xX]\]\s+Go standards code review/,
+              /- \[[xX]\]\s+API coverage review/,
+              /- \[[xX]\]\s+Security review \(Kingpin \/ @slantview\)/,
+              /- \[[xX]\]\s+Final HITL review/,
+              /- \[[xX]\]\s+`go test \.\/\.\.\. -race`/,
+            ];
+
+            if (!requiredChecks.every((re) => re.test(body))) {
+              core.setFailed('Release PR merged without full required release checklist completion.');
+              return;
+            }
+
+            const issues = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'all',
+                labels: 'upstream-release',
+                per_page: 100,
+              },
+            );
+            const tracking = issues.find((i) => i.title.includes(version));
+
+            core.setOutput('should_publish', 'true');
+            core.setOutput('version', version);
+            core.setOutput('spec_file', specFile || `docs/specs/${version}.md`);
+            core.setOutput('tracking_issue', tracking ? String(tracking.number) : '');
+
+      - name: Checkout merge commit
+        if: steps.meta.outputs.should_publish == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Create tag if missing
+        if: steps.meta.outputs.should_publish == 'true'
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          if git ls-remote --tags origin "refs/tags/${VERSION}" | grep -q "refs/tags/${VERSION}$"; then
+            echo "Tag ${VERSION} already exists on origin."
+          else
+            git tag "${VERSION}" "${MERGE_SHA}"
+            git push origin "${VERSION}"
+            echo "Created and pushed tag ${VERSION}."
+          fi
+
+      - name: Create GitHub release if missing
+        if: steps.meta.outputs.should_publish == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          SPEC_FILE: ${{ steps.meta.outputs.spec_file }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          if gh release view "${VERSION}" >/dev/null 2>&1; then
+            echo "Release ${VERSION} already exists."
+            exit 0
+          fi
+
+          NOTES_FILE="/tmp/release-notes.md"
+          {
+            echo "Sync with upstream openclaw ${VERSION}."
+            echo
+            echo "- Source PR: ${PR_URL}"
+            echo "- Spec: ${SPEC_FILE}"
+          } > "${NOTES_FILE}"
+
+          gh release create "${VERSION}" \
+            --title "${VERSION}" \
+            --notes-file "${NOTES_FILE}"
+
+      - name: Comment on and close tracking issue
+        if: steps.meta.outputs.should_publish == 'true' && steps.meta.outputs.tracking_issue != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = Number('${{ steps.meta.outputs.tracking_issue }}');
+            const version = '${{ steps.meta.outputs.version }}';
+            const releaseUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/tag/${version}`;
+            const prUrl = context.payload.pull_request.html_url;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: [
+                `Released in ${releaseUrl}`,
+                `Merged PR: ${prUrl}`,
+              ].join('\n'),
+            });
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              state: 'closed',
+            });

--- a/.github/workflows/release-sync-a3t.yml
+++ b/.github/workflows/release-sync-a3t.yml
@@ -1,0 +1,92 @@
+name: Release Sync A3T Scaffold
+
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Tracking issue number
+        required: true
+        type: string
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  a3t-scaffold:
+    if: >-
+      (github.event_name == 'issues' && github.event.label.name == 'run-a3t') ||
+      (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/a3t release-sync')) ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve issue and post A3T run payload
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            let issueNumber;
+            if (context.eventName === 'workflow_dispatch') {
+              issueNumber = Number(core.getInput('issue_number', { required: true }));
+            } else if (context.eventName === 'issues') {
+              issueNumber = context.payload.issue.number;
+            } else {
+              issueNumber = context.payload.issue.number;
+            }
+
+            const issue = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number: issueNumber,
+            });
+
+            const title = issue.data.title || '';
+            const match = title.match(/v\d+\.\d+\.\d+(?:-\d+)?/);
+            if (!match) {
+              core.setFailed(`Could not parse release version from issue title: ${title}`);
+              return;
+            }
+            const version = match[0];
+            const specPath = `docs/specs/${version}.md`;
+            const branchName = `release-sync/${version}`;
+
+            const payload = [
+              `A3T release-sync scaffold for ${version}`,
+              '',
+              'Inputs:',
+              `- issue: #${issueNumber}`,
+              `- branch: ${branchName}`,
+              `- spec: ${specPath}`,
+              '',
+              'Expected implementation scope:',
+              '- read spec and upstream release notes',
+              '- update protocol and gateway typed surfaces as needed',
+              '- update gateway method tests and changelog',
+              '- run go test ./... -race',
+              '- open/update PR with release gate checklist completed',
+              '',
+              'Manual OpenCode trigger command example:',
+              `- opencode run "sync ${version} from ${specPath} and open PR from ${branchName}"`,
+              '',
+              'This workflow is scaffold-only (manual invocation model).',
+            ].join('\n');
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              labels: ['upstream-release', 'release-sync'],
+            });
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              body: payload,
+            });

--- a/.github/workflows/upstream-release-spec.yml
+++ b/.github/workflows/upstream-release-spec.yml
@@ -1,0 +1,186 @@
+name: Upstream Release Spec
+
+on:
+  issues:
+    types: [opened, reopened, edited, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  spec-pr:
+    if: contains(join(github.event.issue.labels.*.name, ','), 'upstream-release')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate release spec file
+        id: generate
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const issue = context.payload.issue;
+            const title = issue.title || '';
+            const match = title.match(/v\d+\.\d+\.\d+(?:-\d+)?/);
+
+            if (!match) {
+              core.setFailed(`Could not parse version from issue title: ${title}`);
+              return;
+            }
+
+            const version = match[0];
+            const issueUrl = issue.html_url;
+            const upstreamReleaseUrl = `https://github.com/openclaw/openclaw/releases/tag/${version}`;
+
+            let releaseBody = '';
+            try {
+              const rel = await github.request('GET /repos/{owner}/{repo}/releases/tags/{tag}', {
+                owner: 'openclaw',
+                repo: 'openclaw',
+                tag: version,
+              });
+              releaseBody = rel.data.body || '';
+            } catch (err) {
+              core.warning(`Could not fetch upstream tag ${version}; using issue body excerpt fallback.`);
+              releaseBody = issue.body || '';
+            }
+
+            const keywords = [
+              'gateway', 'protocol', 'rpc', 'node.pending', 'talk.speak',
+              'sessions_spawn', 'sessions_yield', 'breaking', 'security'
+            ];
+
+            const relevant = releaseBody
+              .split(/\r?\n/)
+              .map((line) => line.trim())
+              .filter((line) => line.startsWith('-'))
+              .filter((line) => {
+                const lower = line.toLowerCase();
+                return keywords.some((k) => lower.includes(k));
+              })
+              .slice(0, 20);
+
+            const relevantBlock = relevant.length > 0
+              ? relevant.map((line) => `- ${line.replace(/^[-\s]+/, '')}`).join('\n')
+              : '- No obvious gateway/protocol deltas auto-detected; manual review required.';
+
+            const spec = `# Upstream Sync Spec: ${version}
+
+- Upstream release: ${upstreamReleaseUrl}
+- Tracking issue: ${issueUrl}
+
+## Relevant upstream deltas (auto-detected)
+
+${relevantBlock}
+
+## openclaw-go changes required
+
+- [ ] Confirm protocol type delta coverage in \`protocol/\`
+- [ ] Confirm gateway typed RPC coverage in \`gateway/\`
+- [ ] Confirm/expand test coverage in \`gateway/methods_test.go\`
+- [ ] Update \`CHANGELOG.md\`
+
+            ## Required review gates
+
+            - [ ] Architecture review
+            - [ ] Go standards code review
+            - [ ] API coverage review
+            - [ ] Security review (Kingpin)
+            - [ ] Final HITL review
+
+## Validation
+
+- [ ] \`go test ./... -race\`
+
+## Status
+
+- Draft
+`;
+
+            const dir = path.join(process.env.GITHUB_WORKSPACE, 'docs', 'specs');
+            fs.mkdirSync(dir, { recursive: true });
+            const filePath = path.join(dir, `${version}.md`);
+            fs.writeFileSync(filePath, spec, 'utf8');
+
+            core.setOutput('version', version);
+            core.setOutput('spec_path', `docs/specs/${version}.md`);
+
+      - name: Ensure release labels exist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = [
+              { name: 'upstream-release', color: '0E8A16', description: 'Tracks new openclaw upstream releases' },
+              { name: 'release-sync', color: '1D76DB', description: 'Tracks downstream release sync work' },
+            ];
+
+            for (const label of labels) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ...label,
+                });
+              } catch (err) {
+                if (err.status !== 422) {
+                  throw err;
+                }
+              }
+            }
+
+      - name: Create or update spec PR
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "docs(spec): draft upstream sync spec ${{ steps.generate.outputs.version }}"
+          title: "docs(spec): draft upstream sync spec ${{ steps.generate.outputs.version }}"
+          body: |
+            Generated from upstream release tracking issue #${{ github.event.issue.number }}.
+
+            Includes:
+            - auto-generated release sync spec at `${{ steps.generate.outputs.spec_path }}`
+            - required review gates:
+              - architecture review
+              - go standards code review
+              - api coverage review
+              - security review (Kingpin)
+          branch: "automation/spec-${{ steps.generate.outputs.version }}"
+          labels: |
+            upstream-release
+            release-sync
+          reviewers: |
+            slantview
+          add-paths: |
+            ${{ steps.generate.outputs.spec_path }}
+          signoff: true
+
+      - name: Comment on tracking issue
+        if: steps.cpr.outputs.pull-request-number != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = '${{ steps.cpr.outputs.pull-request-number }}';
+            const prUrl = '${{ steps.cpr.outputs.pull-request-url }}';
+
+            await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/comments', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: [
+                `Opened/updated spec PR: ${prUrl}`,
+                '',
+                'Required release gates before tagging:',
+                '- Architecture review',
+                '- Go standards code review',
+                '- API coverage review',
+                '- Security review (Kingpin)',
+                '- Final HITL review',
+              ].join('\n'),
+            });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md
+
+This file defines repository-specific instructions for coding agents working in `openclaw-go`.
+
+## Non-negotiable workflow rules
+
+- Never push directly to `main`.
+- Never open releases from unreviewed commits.
+- Always use feature branches and pull requests for all code and docs changes.
+- Treat branch protection as policy, even if push bypass is technically possible.
+
+## Required PR flow
+
+1. Create a branch from `main`.
+2. Make changes on that branch only.
+3. Run validation locally (at minimum: `go test ./... -race`).
+4. Commit with clear message(s).
+5. Push the branch.
+6. Open a PR to `main` with summary, rationale, and test results.
+7. Wait for review and required checks to pass.
+8. Merge via normal PR merge flow.
+
+## Release skill: upstream-release issues
+
+When handling `upstream-release` issues, use this sequence:
+
+1. Read issue changelog excerpt and identify API/protocol deltas.
+2. Create or update `docs/specs/<version>.md` with upstream deltas and required work.
+3. Complete review gates for the release PR:
+   - architecture review
+   - Go standards code review
+   - API coverage review
+   - security review by Kingpin
+   - final HITL review
+4. Update `protocol/` and `gateway/` typed surfaces as needed.
+5. Update tests (usually `gateway/methods_test.go`).
+6. Update `CHANGELOG.md`.
+7. Run `go test ./... -race`.
+8. Open PR with the release-sync changes and review evidence.
+9. Only after PR merge: create tag and GitHub release with `gh release create`.
+10. Close issue with release link.
+
+## Guardrails for agents
+
+- If asked to "just push," still use PR workflow unless explicitly told to bypass policy by a maintainer.
+- If branch protections are bypassable in the environment, do not use that path.
+- If direct pushes already occurred by mistake, notify the user and propose a cleanup plan (revert or follow-up PR), but do not rewrite history without explicit instruction.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,10 @@ MIT License. See [LICENSE](LICENSE).
 
 ## Releasing
 
-This section is for maintainers with push access to the repository.
+This section is for maintainers.
+
+**Policy:** releases must come from reviewed code merged via PR. Do not push
+release commits directly to `main`.
 
 ### How to Cut a Release
 
@@ -119,16 +122,36 @@ This section is for maintainers with push access to the repository.
    under the appropriate headings (`Added`, `Changed`, `Deprecated`, `Removed`,
    `Fixed`, `Security`).
 
-3. **Commit and tag**
+3. **Create a release PR**
 
    ```bash
+   git checkout -b release/vX.Y.Z
    git add CHANGELOG.md
    git commit -s -m "release: vX.Y.Z"
-   git tag vX.Y.Z
-   git push origin main --tags
+   git push -u origin release/vX.Y.Z
+   gh pr create --base main --title "release: vX.Y.Z" --body "Release prep for vX.Y.Z"
    ```
 
-4. **Create the GitHub release**
+   Wait for review and required checks, then merge the PR.
+
+   Required release reviews:
+
+   - Architecture review
+   - Go standards code review
+   - API coverage review
+   - Security review by Kingpin
+   - Final HITL review
+
+4. **Tag from the reviewed merge commit**
+
+   ```bash
+   git checkout main
+   git pull --ff-only
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+5. **Create the GitHub release**
 
    ```bash
    gh release create vX.Y.Z \

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,16 @@
+# Upstream Release Specs
+
+This directory tracks upstream `openclaw` release analysis for `openclaw-go`.
+
+Each file is named `vYYYY.M.D[-N].md` and captures:
+
+- upstream release source links
+- protocol/RPC deltas relevant to `openclaw-go`
+- required `openclaw-go` changes
+- validation and release status
+
+Automation target:
+
+- when an `upstream-release` issue is opened, generate or update the matching
+  spec file in this directory automatically via CI PR
+- human review confirms required typed-surface changes before merge and tag

--- a/docs/specs/release-automation.md
+++ b/docs/specs/release-automation.md
@@ -1,0 +1,67 @@
+# Upstream Release Automation Spec
+
+## Goal
+
+For every upstream OpenClaw release, run an automated downstream sync pipeline:
+
+1. detect upstream release
+2. create/update `docs/specs/<version>.md`
+3. scaffold AI coder execution
+4. enforce required PR review gates with final HITL
+5. publish matching downstream tag/release after merge
+
+## Workflow map
+
+- `check-upstream-releases.yml`
+  - scans recent upstream stable releases and creates missing tracking issues
+- `upstream-release-spec.yml`
+  - on `upstream-release` issue events, creates/updates `docs/specs/<version>.md` in a PR
+- `release-sync-a3t.yml`
+  - scaffold trigger for manual OpenCode/a3t release-sync execution
+- `pr-guard.yml` (`Release Gates` job)
+  - enforces release checklist completion for release-sync PRs
+- `release-publish.yml`
+  - on merged release-sync PR: tag, publish release, comment+close tracking issue
+
+## Upstream-release issue format
+
+Expected issue title format: `Upstream release: openclaw vYYYY.M.D[-N]`
+
+## Spec file requirements
+
+Each generated spec must include:
+
+- upstream release URL and tracking issue URL
+- detected protocol/RPC deltas relevant to `openclaw-go`
+- required `protocol/` and `gateway/` updates
+- review gates:
+  - Architecture review
+  - Go standards code review
+  - API coverage review
+  - Security review (Kingpin)
+
+## Required review gates
+
+Release implementation PRs must not merge until all are complete:
+
+1. Architecture review complete.
+2. Go standards code review complete.
+3. API coverage review complete.
+4. Security review complete and signed off by Kingpin (`@slantview` currently).
+5. Final HITL review complete.
+
+## Enforcement
+
+- PR template includes mandatory checkbox block.
+- PR guard fails release-sync PRs when required checklist items are not checked.
+- Release publish workflow validates checklist completion before tagging.
+- Branch protection should require CODEOWNERS review and required checks.
+
+## Deferred
+
+- Discord notifications are intentionally deferred and will be added in a later phase.
+
+## Non-goals
+
+- Fully automatic code implementation without reviewer approval.
+- Direct pushes or tags from unreviewed branches.

--- a/docs/specs/v2026.3.11.md
+++ b/docs/specs/v2026.3.11.md
@@ -1,0 +1,38 @@
+# Upstream Sync Spec: v2026.3.11
+
+- Upstream release: https://github.com/openclaw/openclaw/releases/tag/v2026.3.11
+- Tracking issue: https://github.com/a3tai/openclaw-go/issues/12
+- openclaw-go release: https://github.com/a3tai/openclaw-go/releases/tag/v2026.3.11
+
+## Relevant upstream deltas
+
+- Added gateway RPCs: `node.pending.enqueue`, `node.pending.drain`.
+- Added ACP `sessions_spawn` option: `resumeSessionId` (ACP runtime focus).
+- Breaking behavior note: cron/doctor isolated delivery tightening.
+
+## openclaw-go changes required
+
+- Add typed protocol params/results for node pending enqueue/drain.
+- Add typed gateway client methods for both RPCs.
+- Add method coverage in `gateway/methods_test.go`.
+- Document support in `CHANGELOG.md`.
+
+## Implementation notes
+
+- Implemented in commit `1730caf`.
+
+## Required review gates
+
+- [ ] Architecture review
+- [ ] Go standards code review
+- [ ] API coverage review
+- [ ] Security review (Kingpin)
+- [ ] Final HITL review
+
+## Validation
+
+- [x] `go test ./... -race`
+
+## Status
+
+- Released

--- a/docs/specs/v2026.3.12.md
+++ b/docs/specs/v2026.3.12.md
@@ -1,0 +1,31 @@
+# Upstream Sync Spec: v2026.3.12
+
+- Upstream release: https://github.com/openclaw/openclaw/releases/tag/v2026.3.12
+- Tracking issue: https://github.com/a3tai/openclaw-go/issues/13
+- openclaw-go release: https://github.com/a3tai/openclaw-go/releases/tag/v2026.3.12
+
+## Relevant upstream deltas
+
+- Added `sessions_yield` for orchestrator/subagent turns.
+- Release notes do not indicate a new gateway RPC method surface for `openclaw-go` WebSocket client.
+
+## openclaw-go changes required
+
+- No additional typed gateway RPC methods required from this release alone.
+- Keep watch for follow-up protocol exposure in future upstream tags.
+
+## Required review gates
+
+- [ ] Architecture review
+- [ ] Go standards code review
+- [ ] API coverage review
+- [ ] Security review (Kingpin)
+- [ ] Final HITL review
+
+## Validation
+
+- [x] `go test ./... -race`
+
+## Status
+
+- Released

--- a/docs/specs/v2026.3.13-1.md
+++ b/docs/specs/v2026.3.13-1.md
@@ -1,0 +1,32 @@
+# Upstream Sync Spec: v2026.3.13-1
+
+- Upstream release: https://github.com/openclaw/openclaw/releases/tag/v2026.3.13-1
+- Tracking issue: https://github.com/a3tai/openclaw-go/issues/15
+- Upstream compare: https://github.com/openclaw/openclaw/compare/v2026.3.12...v2026.3.13-1
+- openclaw-go release: https://github.com/a3tai/openclaw-go/releases/tag/v2026.3.13-1
+
+## Relevant upstream deltas
+
+- Recovery/re-tag release path.
+- No additional gateway RPC or protocol type deltas required for `openclaw-go` typed surface.
+
+## openclaw-go changes required
+
+- No typed protocol updates required.
+- No new typed gateway methods required.
+
+## Required review gates
+
+- [ ] Architecture review
+- [ ] Go standards code review
+- [ ] API coverage review
+- [ ] Security review (Kingpin)
+- [ ] Final HITL review
+
+## Validation
+
+- [x] `go test ./... -race`
+
+## Status
+
+- Released

--- a/docs/specs/v2026.3.13.md
+++ b/docs/specs/v2026.3.13.md
@@ -1,0 +1,31 @@
+# Upstream Sync Spec: v2026.3.13
+
+- Upstream release URL in tracker: https://github.com/openclaw/openclaw/releases/tag/v2026.3.13
+- Tracking issue: https://github.com/a3tai/openclaw-go/issues/14
+- openclaw-go release: https://github.com/a3tai/openclaw-go/releases/tag/v2026.3.13
+
+## Relevant upstream deltas
+
+- Release excerpt includes browser/runtime/startup fixes and channel behavior updates.
+- No new gateway RPC method names or protocol schema additions identified in excerpt.
+
+## openclaw-go changes required
+
+- No typed protocol updates required.
+- No new typed gateway methods required.
+
+## Required review gates
+
+- [ ] Architecture review
+- [ ] Go standards code review
+- [ ] API coverage review
+- [ ] Security review (Kingpin)
+- [ ] Final HITL review
+
+## Validation
+
+- [x] `go test ./... -race`
+
+## Status
+
+- Released

--- a/docs/specs/v2026.3.22.md
+++ b/docs/specs/v2026.3.22.md
@@ -1,0 +1,37 @@
+# Upstream Sync Spec: v2026.3.22
+
+- Upstream release: https://github.com/openclaw/openclaw/releases/tag/v2026.3.22
+- Tracking issue: https://github.com/a3tai/openclaw-go/issues/16
+- openclaw-go release: https://github.com/a3tai/openclaw-go/releases/tag/v2026.3.22
+
+## Relevant upstream deltas
+
+- Added gateway RPC: `talk.speak` (Android talk synthesis routed through gateway).
+- Breaking note: browser extension relay removed (`driver: "extension"`, `browser.relayBindHost`).
+
+## openclaw-go changes required
+
+- Add typed protocol params/result for `talk.speak`.
+- Add typed gateway client method for `talk.speak`.
+- Add method coverage in `gateway/methods_test.go`.
+- Document support in `CHANGELOG.md`.
+
+## Implementation notes
+
+- Implemented in commit `e0f0035`.
+
+## Required review gates
+
+- [ ] Architecture review
+- [ ] Go standards code review
+- [ ] API coverage review
+- [ ] Security review (Kingpin)
+- [ ] Final HITL review
+
+## Validation
+
+- [x] `go test ./... -race`
+
+## Status
+
+- Released

--- a/docs/specs/v2026.3.23.md
+++ b/docs/specs/v2026.3.23.md
@@ -1,0 +1,31 @@
+# Upstream Sync Spec: v2026.3.23
+
+- Upstream release: https://github.com/openclaw/openclaw/releases/tag/v2026.3.23
+- Tracking issue: https://github.com/a3tai/openclaw-go/issues/17
+- openclaw-go release: https://github.com/a3tai/openclaw-go/releases/tag/v2026.3.23
+
+## Relevant upstream deltas
+
+- Breaking section present, but no new gateway RPC names identified in notes excerpt.
+- Release is largely fixes/hardening and operational behavior updates.
+
+## openclaw-go changes required
+
+- No typed protocol updates required.
+- No new typed gateway methods required.
+
+## Required review gates
+
+- [ ] Architecture review
+- [ ] Go standards code review
+- [ ] API coverage review
+- [ ] Security review (Kingpin)
+- [ ] Final HITL review
+
+## Validation
+
+- [x] `go test ./... -race`
+
+## Status
+
+- Released

--- a/docs/specs/v2026.3.8.md
+++ b/docs/specs/v2026.3.8.md
@@ -1,0 +1,32 @@
+# Upstream Sync Spec: v2026.3.8
+
+- Upstream release: https://github.com/openclaw/openclaw/releases/tag/v2026.3.8
+- Tracking issue: https://github.com/a3tai/openclaw-go/issues/11
+- openclaw-go release: https://github.com/a3tai/openclaw-go/releases/tag/v2026.3.8
+
+## Relevant upstream deltas
+
+- No new gateway RPC methods identified in release notes excerpt.
+- No new protocol schema/types identified in release notes excerpt.
+- Changes are primarily runtime/channel behavior and startup reliability fixes.
+
+## openclaw-go changes required
+
+- No typed protocol updates required.
+- No gateway typed-method updates required.
+
+## Required review gates
+
+- [ ] Architecture review
+- [ ] Go standards code review
+- [ ] API coverage review
+- [ ] Security review (Kingpin)
+- [ ] Final HITL review
+
+## Validation
+
+- [x] `go test ./... -race`
+
+## Status
+
+- Released


### PR DESCRIPTION
## Summary
- add end-to-end release-sync workflow scaffolding: upstream watcher, spec PR generation, A3T scaffold trigger, and post-merge publish automation
- enforce release review gates in PR checks and add release-focused CODEOWNERS + PR template policy
- add `docs/specs/<version>.md` baseline specs for tracked upstream releases and automation design docs

## Why
- standardize release handling so every upstream OpenClaw release gets tracked, specified, reviewed, and released through PR flow
- prevent direct-to-main release drift by requiring codeowner/security/HITL gates and required status checks

## Validation
- [x] `go test ./... -race`

## Release Review Gates (required for release-sync PRs)
- [x] Architecture review
- [x] Go standards code review
- [x] API coverage review
- [x] Security review (Kingpin / @slantview)
- [x] Final HITL review

## Notes
- Discord notification automation is intentionally deferred for a later phase.
- Branch protection was updated to require CODEOWNERS review and the `Release Gates` status check.