### PR TITLE
release: sync upstream v2026.3.1 evidence and coverage

### DIFF
--- a/docs/specs/v2026.3.1.md
+++ b/docs/specs/v2026.3.1.md
@@ -19,7 +19,7 @@
 
 ## Validation evidence
 
-- `python3 scripts/validate_release_sync.py --upstream-root /Users/steverude/prj/openclaw/openclaw --go-root . --version v2026.3.1`
+- `python3 scripts/validate_release_sync.py --upstream-root /tmp/openclaw --go-root . --version v2026.3.1`
   - missing upstream methods: `0`
   - untested release-delta methods: `0`
 


### PR DESCRIPTION
## Summary
- Add `docs/specs/v2026.3.1.md` with upstream compare evidence (`v2026.2.26..v2026.3.1`) and release-delta validation results.
- Include gateway method-wrapper test coverage for `exec.approval.resolve` in `gateway/methods_test.go` to satisfy release-delta coverage checks.
- Document that upstream method parity and release-delta test coverage validate cleanly for this release.

## Release Review Gates (required)
- [x] Architecture review
- [x] Go standards code review
- [x] API coverage review
- [x] Security review (Kingpin / @slantview)
- [x] Final HITL review
- [x] `go test ./... -race`

## Validation
- `python3 scripts/validate_release_sync.py --upstream-root /tmp/openclaw --go-root . --version v2026.3.1`
- `go test ./... -race`
