### PR TITLE
release: sync upstream v2026.3.2 evidence and coverage

### DIFF
--- a/docs/specs/v2026.3.2.md
+++ b/docs/specs/v2026.3.2.md
@@ -20,7 +20,7 @@
 
 ## Validation evidence
 
-- `python3 scripts/validate_release_sync.py --upstream-root /Users/steverude/prj/openclaw/openclaw --go-root . --version v2026.3.2`
+- `python3 scripts/validate_release_sync.py --upstream-root /tmp/openclaw --go-root . --version v2026.3.2`
   - missing upstream methods: `0`
   - untested release-delta methods: `0`
 


### PR DESCRIPTION
## Summary
- Add `docs/specs/v2026.3.2.md` with upstream compare evidence (`v2026.3.1..v2026.3.2`) and release-delta validation results.
- Capture method/schema delta summary for this release and confirm no missing or untested release-delta methods.
- Record validation evidence for release-sync tracking.

## Release Review Gates (required)
- [x] Architecture review
- [x] Go standards code review
- [x] API coverage review
- [x] Security review (Kingpin / @slantview)
- [x] Final HITL review
- [x] `go test ./... -race`

## Validation
- `python3 scripts/validate_release_sync.py --upstream-root /tmp/openclaw --go-root . --version v2026.3.2`
- `go test ./... -race`
