### PR TITLE
fix(ci): guard release/policy scripts against null labels

### DIFF
--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -211,7 +211,11 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const body = pr.body || "";
-            const labels = new Set((pr.labels || []).map((l) => l.name));
+            const labels = new Set(
+              (pr.labels || [])
+                .filter((label) => label && typeof label.name === 'string')
+                .map((label) => label.name),
+            );
 
             const files = await github.paginate(
               github.rest.pulls.listFiles,

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -24,7 +24,11 @@ jobs:
             const pr = context.payload.pull_request;
             const body = pr.body || '';
             const title = pr.title || '';
-            const labels = new Set((pr.labels || []).map((l) => l.name));
+            const labels = new Set(
+              (pr.labels || [])
+                .filter((label) => label && typeof label.name === 'string')
+                .map((label) => label.name),
+            );
 
             const files = await github.paginate(
               github.rest.pulls.listFiles,
@@ -86,7 +90,11 @@ jobs:
             );
 
             const requiredRunNames = ['Test', 'Release Gates', 'Release Smoke', 'Release E2E'];
-            const byName = new Map(checkRuns.map((run) => [run.name, run]));
+            const byName = new Map(
+              (checkRuns || [])
+                .filter((run) => run && typeof run.name === 'string')
+                .map((run) => [run.name, run]),
+            );
             const failedRuns = [];
             for (const name of requiredRunNames) {
               const run = byName.get(name);

--- a/.github/workflows/upstream-release-spec.yml
+++ b/.github/workflows/upstream-release-spec.yml
@@ -19,7 +19,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const labels = (context.payload.issue?.labels || []).map((l) => l.name);
+            const labels = (context.payload.issue?.labels || [])
+              .filter((label) => label && typeof label.name === 'string')
+              .map((label) => label.name);
             const enabled = labels.includes('upstream-release');
             core.setOutput('enabled', enabled ? 'true' : 'false');
 


### PR DESCRIPTION
## Summary
- Guard GitHub script label parsing against null/partial label payloads in `release-publish.yml`, `upstream-release-spec.yml`, and `pr-guard.yml`.
- Guard release-publish check-run indexing against undefined entries before reading `run.name`.
- Prevents merge-time workflow crashes like `Cannot read properties of undefined (reading 'name')`.

## Why
- Some webhook payloads can include sparse objects and should not cause release automation to fail.
- This keeps release publish and release gate workflows fail-safe and deterministic.

## Validation
- Workflow logic only; syntax reviewed in diff and branch checks will execute on PR.