### PR TITLE
ci: Claude Code release-sync + tighten upstream polling

### DIFF
--- a/.github/workflows/check-upstream-releases.yml
+++ b/.github/workflows/check-upstream-releases.yml
@@ -2,7 +2,7 @@ name: Check Upstream Releases
 
 on:
   schedule:
-    - cron: '0 0,6,12,18 * * *'
+    - cron: '*/30 * * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-sync-claude.yml
+++ b/.github/workflows/release-sync-claude.yml
@@ -1,0 +1,227 @@
+name: Release Sync (Claude Code)
+
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Tracking issue number
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  claude-release-sync:
+    if: >-
+      (github.event_name == 'issues' && github.event.label.name == 'run-a3t') ||
+      (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/a3t release-sync')) ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - name: Resolve tracking issue metadata
+        id: meta
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            let issueNumber;
+            if (context.eventName === 'workflow_dispatch') {
+              issueNumber = Number(context.payload.inputs?.issue_number || '');
+            } else {
+              issueNumber = context.payload.issue.number;
+            }
+
+            if (!Number.isFinite(issueNumber) || issueNumber <= 0) {
+              core.setFailed('workflow_dispatch requires a valid issue_number input');
+              return;
+            }
+
+            const issue = await github.rest.issues.get({ owner, repo, issue_number: issueNumber });
+            const title = issue.data.title || '';
+            const match = title.match(/v\d+\.\d+\.\d+(?:-\d+)?/);
+            if (!match) {
+              core.setFailed(`Could not parse release version from issue title: ${title}`);
+              return;
+            }
+
+            const version = match[0];
+            const specPath = `docs/specs/${version}.md`;
+            const branchName = `release-sync/${version}`;
+
+            core.setOutput('issue_number', String(issueNumber));
+            core.setOutput('version', version);
+            core.setOutput('spec_path', specPath);
+            core.setOutput('branch_name', branchName);
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Clone upstream openclaw at release tag
+        run: |
+          git clone https://github.com/openclaw/openclaw /tmp/openclaw
+          git -C /tmp/openclaw checkout "${{ steps.meta.outputs.version }}"
+
+      - name: Ensure release labels exist
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = [
+              { name: 'upstream-release', color: '0E8A16', description: 'Tracks new openclaw upstream releases' },
+              { name: 'release-sync', color: '1D76DB', description: 'Tracks downstream release sync work' },
+              { name: 'run-a3t', color: '5319E7', description: 'Trigger release-sync workflow' },
+            ];
+            for (const label of labels) {
+              try {
+                await github.rest.issues.createLabel({ owner: context.repo.owner, repo: context.repo.repo, ...label });
+              } catch (err) {
+                if (err.status !== 422) throw err;
+              }
+            }
+
+      - name: Add labels to tracking issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number('${{ steps.meta.outputs.issue_number }}'),
+              labels: ['upstream-release', 'release-sync'],
+            });
+
+      - name: Install Claude Code CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
+      - name: Configure git for Claude Code commits
+        run: |
+          git config user.email "steve@a3t.ai"
+          git config user.name "Agent Arlet"
+          git checkout -b "${{ steps.meta.outputs.branch_name }}" 2>/dev/null || git checkout "${{ steps.meta.outputs.branch_name }}"
+
+      - name: Build release sync prompt
+        run: |
+          SPEC_CONTENT=""
+          if [ -f "${{ steps.meta.outputs.spec_path }}" ]; then
+            SPEC_CONTENT=$(cat "${{ steps.meta.outputs.spec_path }}")
+          fi
+
+          cat > /tmp/release-sync-prompt.md << PROMPT
+          You are syncing the openclaw-go Go client library to match upstream openclaw release ${{ steps.meta.outputs.version }}.
+
+          ## Your task
+          1. Read the spec file at ${{ steps.meta.outputs.spec_path }} (if it exists)
+          2. Clone of upstream openclaw is at /tmp/openclaw — compare src/gateway/server-methods-list.ts and protocol/ types against our protocol/ and gateway/ packages
+          3. Add any missing RPC methods to gateway/ and protocol/ types
+          4. Update gateway/methods_test.go to cover new methods
+          5. Update CHANGELOG.md
+          6. Run: go test ./... -race
+          7. Run: python3 scripts/validate_release_sync.py --upstream-root /tmp/openclaw --go-root . --version ${{ steps.meta.outputs.version }}
+          8. Do NOT push — only commit locally
+
+          ## Rules
+          - Only implement methods that exist in upstream openclaw/openclaw — validate against /tmp/openclaw/src/gateway/server-methods-list.ts
+          - Do not add anything from forks or third-party sources
+          - Keep changes minimal and focused to this release delta
+          - Leave review gate checkboxes unchecked in any PR body
+          - All commits must have Signed-off-by: Agent Arlet <steve@a3t.ai>
+
+          ## Spec content
+          $SPEC_CONTENT
+          PROMPT
+
+      - name: Run Claude Code release sync
+        run: |
+          claude --dangerously-skip-permissions \
+            "$(cat /tmp/release-sync-prompt.md)"
+
+      - name: Validate — go test
+        run: go test ./... -race
+
+      - name: Validate — upstream drift check
+        run: |
+          python3 scripts/validate_release_sync.py \
+            --upstream-root /tmp/openclaw \
+            --go-root . \
+            --version "${{ steps.meta.outputs.version }}" || true
+
+      - name: Create or update release-sync PR
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ steps.meta.outputs.branch_name }}
+          commit-message: "chore(release): sync ${{ steps.meta.outputs.version }} from upstream"
+          title: "chore(release): sync ${{ steps.meta.outputs.version }} from upstream"
+          labels: |
+            upstream-release
+            release-sync
+          draft: true
+          signoff: true
+          body: |
+            ## Summary
+            Automated release sync for upstream openclaw `${{ steps.meta.outputs.version }}`.
+
+            - Source spec: `${{ steps.meta.outputs.spec_path }}`
+            - Implemented by: Claude Code (claude-sonnet)
+            - Validated: `go test ./... -race` ✅
+
+            ## Release Review Gates (required before merge)
+            - [ ] Architecture review
+            - [ ] Go standards code review
+            - [ ] API coverage review
+            - [ ] Security review (Kingpin / @slantview)
+            - [ ] Final HITL review
+            - [ ] `go test ./... -race`
+
+      - name: Comment on tracking issue
+        if: steps.cpr.outputs.pull-request-url != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number('${{ steps.meta.outputs.issue_number }}'),
+              body: [
+                `Claude Code release-sync completed for ${{ steps.meta.outputs.version }}.`,
+                `Draft PR: ${{ steps.cpr.outputs.pull-request-url }}`,
+                '',
+                'Review gates required before merge — check PR description.',
+              ].join('\n'),
+            });
+
+      - name: Comment on failure
+        if: failure() && steps.meta.outputs.issue_number != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number('${{ steps.meta.outputs.issue_number }}'),
+              body: [
+                `Claude Code release-sync failed for ${{ steps.meta.outputs.version }}.`,
+                `Run: ${runUrl}`,
+              ].join('\n'),
+            });

--- a/.github/workflows/upstream-release-spec.yml
+++ b/.github/workflows/upstream-release-spec.yml
@@ -229,7 +229,7 @@ jobs:
               ].join('\n'),
             });
 
-      - name: Trigger OpenCode release-sync run
+      - name: Trigger Claude Code release-sync run
         if: steps.gate.outputs.enabled == 'true' && steps.cpr.outputs.pull-request-number != ''
         uses: actions/github-script@v7
         with:
@@ -238,11 +238,11 @@ jobs:
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              workflow_id: 'release-sync-a3t.yml',
+              workflow_id: 'release-sync-claude.yml',
               ref: 'main',
               inputs: {
                 issue_number: issueNumber,
               },
             });
 
-            core.info(`Triggered release-sync-a3t.yml for issue #${issueNumber}`);
+            core.info(`Triggered release-sync-claude.yml for issue #${issueNumber}`);


### PR DESCRIPTION
## What

- **New workflow**: `release-sync-claude.yml` — Claude Code (claude-sonnet) automatically implements upstream release deltas when a new openclaw release is detected
- **Upstream polling**: every 30 minutes (was every 6 hours)
- **Wired**: `upstream-release-spec.yml` now triggers Claude workflow instead of OpenCode

## How it works

1. `check-upstream-releases.yml` polls openclaw/openclaw every 30min
2. New release detected → tracking issue created with `upstream-release` label
3. `upstream-release-spec.yml` generates a diff spec + triggers Claude sync
4. `release-sync-claude.yml` runs Claude Code to implement the delta, validates with `go test ./... -race`, opens draft PR
5. Human reviews draft PR, checks review gates, merges
6. `release-publish.yml` auto-tags + publishes release

## Secrets wired
- `ANTHROPIC_API_KEY` ✅ (set in repo secrets)

## Review gates unchanged
Draft PRs still require: Architecture review, Go standards review, API coverage review, Security review, Final HITL review — before `release-publish.yml` will tag + publish.