### PR TITLE
fix(ci): add base: main to release-sync create-pull-request

### DIFF
--- a/.github/workflows/release-sync-claude.yml
+++ b/.github/workflows/release-sync-claude.yml
@@ -169,6 +169,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          base: main
           branch: ${{ steps.meta.outputs.branch_name }}
           commit-message: "chore(release): sync ${{ steps.meta.outputs.version }} from upstream"
           title: "chore(release): sync ${{ steps.meta.outputs.version }} from upstream"


### PR DESCRIPTION
Fixes release-sync-claude workflow failure: 'base and branch must be different branches'. Root cause: workflow checks out release-sync/VERSION then create-pull-request has no explicit base so it tries to create a PR from the branch to itself. Fix: add base: main.