### PR TITLE
feat: add plugin.approval.{request,waitDecision,resolve} methods

### DIFF
--- a/gateway/misc.go
+++ b/gateway/misc.go
@@ -22,6 +22,9 @@ func (c *Client) PushTest(ctx context.Context, params protocol.PushTestParams) (
 }
 
 // BrowserRequest makes a browser request via the gateway.
+//
+// Deprecated: browser.request is not present in upstream OpenClaw's BASE_METHODS
+// and is a deprecation candidate. Avoid using this in new code.
 func (c *Client) BrowserRequest(ctx context.Context, params any) (json.RawMessage, error) {
 	return c.sendRPC(ctx, string(protocol.MethodBrowserRequest), params)
 }

--- a/gateway/plugin_approvals.go
+++ b/gateway/plugin_approvals.go
@@ -1,0 +1,40 @@
+package gateway
+
+import (
+	"context"
+
+	"github.com/a3tai/openclaw-go/protocol"
+)
+
+// PluginApprovalRequest submits a new plugin approval request.
+// The gateway broadcasts a "plugin.approval.requested" event to connected approval clients
+// and waits for a decision. If no approval clients are connected, the decision is nil.
+// Requires the operator.approvals scope.
+func (c *Client) PluginApprovalRequest(ctx context.Context, params protocol.PluginApprovalRequestParams) (*protocol.PluginApprovalRequestResult, error) {
+	var result protocol.PluginApprovalRequestResult
+	if err := c.sendRPCTyped(ctx, string(protocol.MethodPluginApprovalRequest), params, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// PluginApprovalWaitDecision waits for a decision on a pending plugin approval.
+// Requires the operator.approvals scope.
+func (c *Client) PluginApprovalWaitDecision(ctx context.Context, params protocol.PluginApprovalWaitDecisionParams) (*protocol.PluginApprovalWaitDecisionResult, error) {
+	var result protocol.PluginApprovalWaitDecisionResult
+	if err := c.sendRPCTyped(ctx, string(protocol.MethodPluginApprovalWaitDecision), params, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// PluginApprovalResolve resolves a pending plugin approval request.
+// decision must be one of: "allow-once", "allow-always", "deny".
+// Requires the operator.approvals scope.
+func (c *Client) PluginApprovalResolve(ctx context.Context, params protocol.PluginApprovalResolveParams) (*protocol.PluginApprovalResolveResult, error) {
+	var result protocol.PluginApprovalResolveResult
+	if err := c.sendRPCTyped(ctx, string(protocol.MethodPluginApprovalResolve), params, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -155,6 +155,10 @@ const (
 	EventExecFinished EventName = "exec.finished"
 	// EventExecDenied is emitted when command execution is denied.
 	EventExecDenied EventName = "exec.denied"
+	// EventPluginApprovalRequested is emitted when a plugin action needs approval.
+	EventPluginApprovalRequested EventName = "plugin.approval.requested"
+	// EventPluginApprovalResolved is emitted when a plugin approval is resolved.
+	EventPluginApprovalResolved EventName = "plugin.approval.resolved"
 )
 
 // MethodName identifies a gateway RPC method name.
@@ -176,6 +180,7 @@ const (
 	MethodAgentsUpdate    MethodName = "agents.update"
 
 	// Browser and channel integration.
+	// Deprecated: browser.request is not in upstream BASE_METHODS; treat as a deprecation candidate.
 	MethodBrowserRequest MethodName = "browser.request"
 	MethodChannelsLogout MethodName = "channels.logout"
 	MethodChannelsStatus MethodName = "channels.status"
@@ -219,6 +224,11 @@ const (
 	MethodExecApprovalsNodeGet MethodName = "exec.approvals.node.get"
 	MethodExecApprovalsNodeSet MethodName = "exec.approvals.node.set"
 	MethodExecApprovalsSet     MethodName = "exec.approvals.set"
+
+	// Plugin approvals.
+	MethodPluginApprovalRequest      MethodName = "plugin.approval.request"
+	MethodPluginApprovalWaitDecision MethodName = "plugin.approval.waitDecision"
+	MethodPluginApprovalResolve      MethodName = "plugin.approval.resolve"
 
 	// Gateway status and logs.
 	MethodGatewayIdentityGet MethodName = "gateway.identity.get"
@@ -2227,4 +2237,76 @@ type WebLoginStartParams struct {
 type WebLoginWaitParams struct {
 	TimeoutMs *int   `json:"timeoutMs,omitempty"`
 	AccountID string `json:"accountId,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// plugin.approval types
+// ---------------------------------------------------------------------------
+
+// PluginApprovalRequestParams are the params for "plugin.approval.request".
+type PluginApprovalRequestParams struct {
+	PluginID             *string `json:"pluginId,omitempty"`
+	Title                string  `json:"title"`
+	Description          string  `json:"description"`
+	Severity             *string `json:"severity,omitempty"` // "info", "warning", "critical"
+	ToolName             *string `json:"toolName,omitempty"`
+	ToolCallID           *string `json:"toolCallId,omitempty"`
+	AgentID              *string `json:"agentId,omitempty"`
+	SessionKey           *string `json:"sessionKey,omitempty"`
+	TurnSourceChannel    *string `json:"turnSourceChannel,omitempty"`
+	TurnSourceTo         *string `json:"turnSourceTo,omitempty"`
+	TurnSourceAccountID  *string `json:"turnSourceAccountId,omitempty"`
+	TurnSourceThreadID   any     `json:"turnSourceThreadId,omitempty"` // string or number
+	TimeoutMs            *int    `json:"timeoutMs,omitempty"`
+	TwoPhase             *bool   `json:"twoPhase,omitempty"`
+}
+
+// PluginApprovalRequestResult is the result of "plugin.approval.request".
+type PluginApprovalRequestResult struct {
+	ID          string  `json:"id"`
+	Status      string  `json:"status,omitempty"` // "accepted" (twoPhase first response)
+	Decision    *string `json:"decision"`
+	CreatedAtMs int64   `json:"createdAtMs"`
+	ExpiresAtMs int64   `json:"expiresAtMs"`
+}
+
+// PluginApprovalWaitDecisionParams are the params for "plugin.approval.waitDecision".
+type PluginApprovalWaitDecisionParams struct {
+	ID string `json:"id"`
+}
+
+// PluginApprovalWaitDecisionResult is the result of "plugin.approval.waitDecision".
+type PluginApprovalWaitDecisionResult struct {
+	ID          string  `json:"id"`
+	Decision    *string `json:"decision"` // "allow-once", "allow-always", "deny", or null
+	CreatedAtMs *int64  `json:"createdAtMs,omitempty"`
+	ExpiresAtMs *int64  `json:"expiresAtMs,omitempty"`
+}
+
+// PluginApprovalResolveParams are the params for "plugin.approval.resolve".
+type PluginApprovalResolveParams struct {
+	ID       string `json:"id"`
+	Decision string `json:"decision"` // "allow-once", "allow-always", "deny"
+}
+
+// PluginApprovalResolveResult is the result of "plugin.approval.resolve".
+type PluginApprovalResolveResult struct {
+	OK bool `json:"ok"`
+}
+
+// PluginApprovalRequestedEvent is the payload of a "plugin.approval.requested" event.
+type PluginApprovalRequestedEvent struct {
+	ID          string                      `json:"id"`
+	Request     PluginApprovalRequestParams `json:"request"`
+	CreatedAtMs int64                       `json:"createdAtMs"`
+	ExpiresAtMs int64                       `json:"expiresAtMs"`
+}
+
+// PluginApprovalResolvedEvent is the payload of a "plugin.approval.resolved" event.
+type PluginApprovalResolvedEvent struct {
+	ID         string                       `json:"id"`
+	Decision   string                       `json:"decision"`
+	ResolvedBy *string                      `json:"resolvedBy,omitempty"`
+	Ts         int64                        `json:"ts"`
+	Request    *PluginApprovalRequestParams `json:"request,omitempty"`
 }


### PR DESCRIPTION
## Summary

Implements the three missing plugin approval RPC methods identified in the upstream API drift report (#41).

## Changes

**protocol/protocol.go**
- Added `MethodPluginApprovalRequest`, `MethodPluginApprovalWaitDecision`, `MethodPluginApprovalResolve` constants
- Added `EventPluginApprovalRequested`, `EventPluginApprovalResolved` event constants
- Added full type set: `PluginApprovalRequestParams`, `PluginApprovalRequestResult`, `PluginApprovalWaitDecisionParams`, `PluginApprovalWaitDecisionResult`, `PluginApprovalResolveParams`, `PluginApprovalResolveResult`, `PluginApprovalRequestedEvent`, `PluginApprovalResolvedEvent`
- Marked `MethodBrowserRequest` as deprecated (not in upstream BASE_METHODS)

**gateway/plugin_approvals.go** (new file)
- `PluginApprovalRequest` — submits a plugin approval request; waits for decision (or returns nil decision if no approval clients)
- `PluginApprovalWaitDecision` — waits for a decision on an in-flight approval (twoPhase support)
- `PluginApprovalResolve` — resolves a pending approval with allow-once/allow-always/deny

**gateway/misc.go**
- Deprecated `BrowserRequest` per policy (extra method not in upstream)

## Relation to upstream

Types and method signatures are derived directly from the upstream TypeScript implementation in `src/gateway/server-methods/plugin-approval.ts` and `src/gateway/protocol/schema/plugin-approvals.ts`. The plugin approval flow mirrors the existing exec approval pattern.

Closes #41