### PR TITLE
ci: add GitHub Pages deploy workflow for docs site

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,59 @@
+name: Deploy Docs
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build VitePress site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: docs-site/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: docs-site
+
+      - name: Build VitePress site
+        run: npm run build
+        working-directory: docs-site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: docs-site/.vitepress/dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac553fd0d31 # v4
+        id: deployment


### PR DESCRIPTION
## Summary

Adds the GitHub Pages deploy workflow for the VitePress docs site. Triggers on version tags (`v*`) and manual `workflow_dispatch`.

## Setup required

Repo Settings > Pages > Source: **GitHub Actions**

Once enabled, the site will be live at `https://a3tai.github.io/openclaw-go/`

## Workflow

1. Checkout with full history (for VitePress `lastUpdated`)
2. Node 22 + `npm ci` in `docs-site/`
3. `npm run build` produces static site in `.vitepress/dist/`
4. Upload as Pages artifact
5. Deploy to GitHub Pages

All action SHAs are pinned.