### PR TITLE
chore: add agent dotfiles and gitignore node_modules/binaries

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,11 @@ temp/
 # Build output
 dist/
 build/
+
+# Node modules
+node_modules/
+
+# Example binaries
+examples/*/[a-z]*
+!examples/*/main.go
+!examples/*/*.md

--- a/.opencode/skills/docs-design/SKILL.md
+++ b/.opencode/skills/docs-design/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: docs-design
+description: Improve the visual design and UX of the VitePress docs site — layout, colors, typography, components, and responsiveness
+license: MIT
+metadata:
+  audience: designers
+  workflow: docs
+---
+
+## What I do
+
+Analyze and improve the visual design, user experience, and polish of the openclaw-go documentation site built with VitePress.
+
+## When to use me
+
+Use this skill when the docs site needs visual improvements, when adding new UI components, or when the site feels rough or inconsistent.
+
+## Design system
+
+### Brand colors
+- **Primary (amber)**: `#f5a623`
+- **Primary hover**: `#d4891e`
+- **Primary deep**: `#b8730f`
+- **Primary soft**: `rgba(245, 166, 35, 0.12)`
+
+### Dark mode surfaces
+- **Background**: `#0d0d0f`
+- **Soft background**: `#1a1a1f`
+- **Mute background**: `#141418`
+- **Alt background**: `#101013`
+- **Border/divider**: `#2a2a35`
+
+### Mascot
+- File: `docs-site/public/mascot-gpt.png` — a Go gopher with lobster claws
+- Used as: navbar logo (64x64px) and favicon
+- Style: playful but professional
+
+## Key files to edit
+
+| File | What it controls |
+|------|-----------------|
+| `docs-site/.vitepress/theme/custom.css` | All custom styles — colors, component overrides, dark mode |
+| `docs-site/.vitepress/theme/index.ts` | Theme setup, layout component registration |
+| `docs-site/.vitepress/config.mts` | Nav, sidebar, logo, footer, head meta |
+| `docs-site/index.md` | Home page hero, feature cards, install block |
+
+## Design principles
+
+1. **Dark-first** — the site is primarily viewed in dark mode. Light mode should work but dark mode is the priority.
+2. **Readable code** — code blocks need high contrast, clear syntax highlighting, and generous padding.
+3. **Amber accents** — use the brand amber sparingly for links, active states, and interactive elements. Don't overwhelm with color.
+4. **Whitespace** — generous spacing between sections. Don't crowd content.
+5. **Mobile-friendly** — test at 375px width. Navigation, code blocks, and tables should be usable on mobile.
+
+## Improvement areas to consider
+
+### Homepage
+- Hero section: gradient, tagline sizing, CTA button styling
+- Feature cards: hover effects, icon sizing, card grid layout
+- Install/quickstart section: code block styling, spacing
+
+### Navigation
+- Logo sizing and alignment in the navbar
+- Active state styling for nav items
+- Sidebar width and item spacing
+- Mobile hamburger menu behavior
+
+### Content pages
+- Heading hierarchy and spacing
+- Table styling (borders, padding, zebra striping)
+- Inline code vs code block contrast
+- Tip/warning/info callout boxes
+- "On this page" ToC sidebar styling
+
+### Typography
+- Font stack for body, headings, and code
+- Line height and paragraph spacing
+- Heading sizes and weight progression
+
+### Interactions
+- Link hover states
+- Button focus rings
+- Smooth scroll behavior
+- Page transition effects
+
+## Workflow
+
+1. **Assess current state** — take screenshots, identify issues
+2. **Prioritize** — fix broken/ugly things first, polish second
+3. **Edit CSS** — make changes in `custom.css`
+4. **Build and preview**:
+   ```sh
+   cd docs-site && npm run build && npm run preview
+   ```
+5. **Compare** — screenshot before/after
+6. **Test responsiveness** — check at 375px, 768px, and 1440px widths
+7. **Test both themes** — verify changes work in dark and light mode
+
+## Rules
+
+- Stay within VitePress's theming system — override CSS variables and class selectors, don't fight the framework
+- Keep custom CSS maintainable — comment sections, use the existing color variables
+- Don't add JavaScript for purely visual effects — CSS-only where possible
+- Test in both dark and light mode even though dark is primary

--- a/.opencode/skills/docs-site/SKILL.md
+++ b/.opencode/skills/docs-site/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: docs-site
+description: Build, preview, and update the VitePress documentation site in docs-site/
+license: MIT
+metadata:
+  audience: contributors
+  workflow: docs
+---
+
+## What I do
+
+Manage the openclaw-go VitePress documentation site — build it, preview it, add or update pages, and fix issues.
+
+## When to use me
+
+Use this skill when working on the docs site, adding new package documentation, updating guides, or debugging build/deploy issues.
+
+## Site structure
+
+```
+docs-site/
+  .vitepress/
+    config.mts          — VitePress configuration (nav, sidebar, theme)
+    theme/
+      index.ts          — custom theme extending DefaultTheme
+      custom.css         — amber brand colors, dark mode, component styles
+  public/
+    mascot-gpt.png      — site logo and favicon
+  index.md              — home page (hero + feature cards)
+  changelog.md          — includes ../CHANGELOG.md via @include directive
+  guide/
+    getting-started.md
+    authentication.md
+    streaming.md
+  packages/
+    gateway.md
+    protocol.md
+    chatcompletions.md
+    openresponses.md
+    toolsinvoke.md
+    discovery.md
+    acp.md
+```
+
+## Commands
+
+All commands run from `docs-site/`:
+
+| Command | Purpose |
+|---------|---------|
+| `npm ci` | Install dependencies (clean) |
+| `npm run dev` | Dev server with hot reload |
+| `npm run build` | Build static site to `.vitepress/dist/` |
+| `npm run preview` | Serve built site locally at `http://localhost:4173/openclaw-go/` |
+
+## Key configuration
+
+- **Base path**: `/openclaw-go/` (GitHub Pages project site)
+- **Clean URLs**: enabled (no `.html` extensions)
+- **Search**: local provider
+- **Logo/favicon**: `/mascot-gpt.png`
+- **Edit links**: point to `https://github.com/a3tai/openclaw-go/edit/main/docs-site/:path`
+
+## Adding a new package page
+
+1. Create `docs-site/packages/<name>.md`
+2. Add to sidebar in `.vitepress/config.mts` under `/packages/` items
+3. Add a feature card to `index.md` if appropriate
+4. Build and preview to verify
+
+## Adding a new guide page
+
+1. Create `docs-site/guide/<name>.md`
+2. Add to sidebar in `.vitepress/config.mts` under `/guide/` items
+3. Add "Next Steps" links from related pages
+4. Build and preview to verify
+
+## Deployment
+
+The site deploys to GitHub Pages via `.github/workflows/docs-deploy.yml`:
+- Triggered on version tags (`v*`) or manual `workflow_dispatch`
+- Uses Node 22, `npm ci`, `npm run build`
+- Deploys `.vitepress/dist/` as a Pages artifact
+
+## Rules
+
+- Always build and preview before committing docs changes
+- The changelog page auto-includes `../CHANGELOG.md` — do not duplicate content
+- Use the amber brand color `#f5a623` for any new styled elements
+- Keep code examples consistent with actual library API

--- a/.opencode/skills/go-test/SKILL.md
+++ b/.opencode/skills/go-test/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: go-test
+description: Run go test with race detector, analyze failures, fix issues, and re-run until green
+license: MIT
+metadata:
+  audience: developers
+  workflow: testing
+---
+
+## What I do
+
+Run the Go test suite with the race detector, analyze any failures, apply fixes, and iterate until all tests pass.
+
+## When to use me
+
+Use this skill before committing changes, before opening a PR, or when asked to fix failing tests.
+
+## Workflow
+
+1. **Run the full test suite**:
+   ```sh
+   go test ./... -race -v
+   ```
+
+2. **Analyze failures** — for each failing test:
+   - Identify the test function and file (e.g., `gateway/methods_test.go:TestChatSend`)
+   - Read the test code and the code under test
+   - Determine root cause: type mismatch, missing mock, logic error, race condition, etc.
+
+3. **Fix the issue** — apply the minimal correct fix:
+   - If the test expectation is wrong (API changed), update the test
+   - If the implementation is wrong, fix the implementation
+   - If a new type/method is missing, add it
+   - Never delete or skip tests to make the suite pass
+
+4. **Re-run tests**:
+   ```sh
+   go test ./... -race
+   ```
+
+5. **Repeat** steps 2-4 until all tests pass.
+
+6. **Run vet** as a final check:
+   ```sh
+   go vet ./...
+   ```
+
+## Test patterns in this repo
+
+- **Table-driven tests** — most tests use `[]struct{ name string; ... }` with `t.Run()`
+- **Mock gateway** — `gateway/methods_test.go` uses a mock WebSocket server that validates request frames and sends response frames
+- **Race detector** — always use `-race`; the gateway client is concurrent and race bugs are real
+- **Coverage target** — aim for 100% statement coverage on library packages
+
+## Key test files
+
+| File | What it covers |
+|------|---------------|
+| `gateway/methods_test.go` | All 96+ typed RPC methods |
+| `gateway/client_test.go` | Connection lifecycle, handshake, reconnect |
+| `protocol/types_test.go` | Serialization round-trips |
+| `protocol/parse_test.go` | Frame parsing edge cases |
+| `chatcompletions/client_test.go` | HTTP client, SSE streaming |
+| `openresponses/client_test.go` | Responses API, SSE events |
+| `toolsinvoke/client_test.go` | Tools invoke HTTP client |
+| `discovery/browser_test.go` | mDNS discovery |
+| `acp/server_test.go` | JSON-RPC dispatch, handler interface |
+
+## Rules
+
+- Never use `-count=0` or `t.Skip()` to hide failures
+- Always include `-race` flag
+- Fix the root cause, not the symptom
+- If a test is flaky, fix the flakiness rather than retrying

--- a/.opencode/skills/pr-review/SKILL.md
+++ b/.opencode/skills/pr-review/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: pr-review
+description: Review pull requests against repo standards — Go conventions, test coverage, race detector, CHANGELOG, and docs
+license: MIT
+metadata:
+  audience: reviewers
+  workflow: github
+---
+
+## What I do
+
+Perform a structured code review of a pull request against the openclaw-go repository standards.
+
+## When to use me
+
+Use this skill when reviewing a PR, or when asked to check if a branch is ready to merge.
+
+## Review checklist
+
+### 1. Go standards
+- [ ] Exported types and functions have GoDoc comments
+- [ ] Error handling follows `if err != nil { return ... }` pattern — no swallowed errors
+- [ ] Naming is idiomatic Go (MixedCaps, not underscores; receiver names are short)
+- [ ] No `panic` in library code — return errors instead
+- [ ] `context.Context` is the first parameter where applicable
+- [ ] JSON struct tags use `omitempty` where the zero value is valid to omit
+
+### 2. Test coverage
+- [ ] New public functions have corresponding test cases
+- [ ] Tests use table-driven patterns consistent with existing tests
+- [ ] Both success and error paths are covered
+- [ ] `go test ./... -race` passes cleanly
+- [ ] No test files import packages they shouldn't (e.g., no circular deps)
+
+### 3. Protocol correctness
+- [ ] New types match the upstream OpenClaw wire format exactly
+- [ ] Method strings match the upstream RPC names (e.g., `"sessions.get"`)
+- [ ] No breaking changes to existing exported types without a major version bump discussion
+
+### 4. CHANGELOG
+- [ ] New features, fixes, or breaking changes have a `[Unreleased]` entry
+- [ ] Entries follow Keep a Changelog format
+- [ ] Links to upstream version or issue are included where relevant
+
+### 5. Documentation
+- [ ] `docs-site/packages/` pages updated if public API surface changed
+- [ ] `docs/` markdown files updated if applicable
+- [ ] README badges and links still work
+
+### 6. Security
+- [ ] No hardcoded tokens, passwords, or secrets
+- [ ] TLS defaults are safe (no `InsecureSkipVerify: true` in production code)
+- [ ] No user input passed unsanitized into shell commands or SQL
+
+### 7. Git hygiene
+- [ ] Commits have clear messages describing the "why"
+- [ ] No unrelated changes bundled into the PR
+- [ ] Branch is based on current `main`
+- [ ] No force-pushes to shared branches
+
+## Output format
+
+Provide the review as a structured summary:
+1. **Verdict** — Approve / Request Changes / Comment
+2. **Summary** — 1-2 sentence overview
+3. **Findings** — list each issue with file:line reference and severity (blocking / suggestion / nit)
+4. **Tests** — confirm `go test ./... -race` results

--- a/.opencode/skills/release-tag/SKILL.md
+++ b/.opencode/skills/release-tag/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: release-tag
+description: Create a GitHub release with tag after a PR merge — follows the repo's tag and gh release create workflow
+license: MIT
+metadata:
+  audience: maintainers
+  workflow: github
+---
+
+## What I do
+
+Create a Git tag and GitHub release after a release PR has been merged to `main`.
+
+## When to use me
+
+Use this skill only after a release PR has been merged to `main` and all CI checks have passed. Never use this before the PR is merged.
+
+## Pre-conditions
+
+Before proceeding, verify ALL of these:
+
+1. The release PR is merged to `main`
+2. CI passed on the merge commit
+3. `go test ./... -race` passes locally on `main`
+4. `CHANGELOG.md` has entries under the version being released
+5. No other release is in-flight
+
+## Workflow
+
+1. **Checkout and pull main**:
+   ```sh
+   git checkout main
+   git pull origin main
+   ```
+
+2. **Determine version** — read from `CHANGELOG.md`:
+   - Find the first `## [x.y.z]` heading that isn't `[Unreleased]`
+   - The tag will be `v<x.y.z>`
+
+3. **Verify the tag doesn't exist**:
+   ```sh
+   git tag -l "v<x.y.z>"
+   ```
+
+4. **Build release notes** from the CHANGELOG section for this version. Include:
+   - Summary of what changed
+   - Link to the upstream OpenClaw version if this is a sync release
+   - Link to the PR that was merged
+
+5. **Create the tag and release**:
+   ```sh
+   git tag v<x.y.z>
+   git push origin v<x.y.z>
+   gh release create v<x.y.z> --title "v<x.y.z>" --notes "<release notes>"
+   ```
+
+6. **Verify the release**:
+   ```sh
+   gh release view v<x.y.z>
+   ```
+
+7. **Close related issues** — if there's an upstream-release issue, close it with a link to the release.
+
+## Version format
+
+This project uses semantic versioning:
+- **Patch** (`x.y.Z`) — bug fixes, test improvements, doc updates
+- **Minor** (`x.Y.0`) — new features (new RPC methods, new packages), backward compatible
+- **Major** (`X.0.0`) — breaking changes to exported API (should be rare)
+
+## Rules
+
+- Never create a tag from an unmerged branch
+- Never create a release without passing tests
+- Never skip the CHANGELOG — if there's no entry, something was missed
+- One release per merged PR — do not batch
+- The docs-deploy workflow triggers automatically on `v*` tags

--- a/.opencode/skills/upstream-release/SKILL.md
+++ b/.opencode/skills/upstream-release/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: upstream-release
+description: Handle upstream-release issues — read changelog deltas, update spec docs, sync protocol and gateway types, run tests, open PR, tag release
+license: MIT
+metadata:
+  audience: maintainers
+  workflow: github
+---
+
+## What I do
+
+Automate the full upstream release sync workflow for openclaw-go when a new OpenClaw gateway version is published.
+
+## When to use me
+
+Use this skill when handling GitHub issues labeled `upstream-release` or when a new OpenClaw gateway version needs to be synced into this library.
+
+## Workflow
+
+1. **Read the issue** — extract the changelog excerpt and identify API/protocol deltas (new RPCs, changed params, removed fields, new event types).
+
+2. **Create or update the spec doc** — write `docs/specs/<version>.md` summarizing upstream deltas and required work items.
+
+3. **Update protocol types** — add or modify types in `protocol/` to match the upstream wire format:
+   - New `*Params` and `*Result` structs
+   - New constants (methods, event names, scopes)
+   - Updated `json` tags and field types
+   - Run `go vet ./protocol/...` after changes
+
+4. **Update gateway methods** — add typed convenience methods in `gateway/methods.go`:
+   - Follow the existing pattern: marshal params → `client.Send()` → unmarshal result
+   - Method name matches the RPC name in PascalCase
+   - Include GoDoc comment referencing the RPC method string
+
+5. **Update tests** — add test cases in `gateway/methods_test.go`:
+   - Follow existing table-driven test pattern
+   - Mock the expected request/response exchange
+   - Cover both success and error paths
+
+6. **Update CHANGELOG.md** — add entries under `[Unreleased] > Added` following Keep a Changelog format.
+
+7. **Update docs-site package pages** — add new methods to `docs-site/packages/gateway.md` and any new types to `docs-site/packages/protocol.md`.
+
+8. **Run validation**:
+   ```sh
+   go test ./... -race
+   go vet ./...
+   ```
+
+9. **Complete review gates** before marking the PR ready:
+   - Architecture review — confirm type design matches upstream semantics
+   - Go standards review — idiomatic naming, error handling, documentation
+   - API coverage review — every new upstream RPC has a typed method and test
+   - Security review — no credential leaks, safe defaults
+
+10. **Open PR** to `main` with:
+    - Summary of upstream changes
+    - Link to the upstream-release issue
+    - Test results pasted in the PR body
+
+11. **After PR merge only** — create tag and GitHub release:
+    ```sh
+    git tag v<version>
+    gh release create v<version> --title "v<version>" --notes "..."
+    ```
+
+12. **Close the issue** with a link to the release.
+
+## Key files
+
+- `protocol/types.go` — wire types
+- `protocol/constants.go` — method strings, scopes, roles
+- `gateway/methods.go` — typed RPC methods
+- `gateway/methods_test.go` — method tests
+- `CHANGELOG.md` — release notes
+- `docs/specs/` — version spec documents
+- `docs-site/packages/` — published package docs
+
+## Rules
+
+- Never push directly to `main` — always use feature branches and PRs.
+- Branch naming: `issue/<number>-upstream-release-v<version>`
+- One upstream version per PR — do not batch multiple releases.
+- Every new RPC must have a typed method, a test, a CHANGELOG entry, and a docs update.


### PR DESCRIPTION
- Commit `.claude/settings.json` and `.opencode/skills/` (agent workflow configs)
- Gitignore `node_modules/` everywhere
- Gitignore example build binaries (e.g. `examples/cron/cron`)