### PR TITLE
fix(ci): correct deploy-pages action SHA

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -55,5 +55,5 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac553fd0d31 # v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
         id: deployment


### PR DESCRIPTION
The pinned SHA for `actions/deploy-pages@v4` was truncated (`...53fd0d31` vs `...b3c0c03e`), causing the deploy job to fail. One character fix.