### PR TITLE
fix(release): auto-publish on title pattern + label reminder in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,10 @@
 
 ## Release Review Gates (required for release-sync PRs)
 
+> ⚠️ Release-sync PRs must have the `release-sync` label applied **before merge** to trigger
+> automatic publishing. The `release-sync-claude` workflow sets this automatically; if filing
+> manually, add it yourself or the publish workflow will fall back to title-pattern detection.
+
 - [ ] Architecture review
 - [ ] Go standards code review
 - [ ] API coverage review

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -24,7 +24,8 @@ jobs:
         github.event.pull_request.merged == true &&
         (
           contains(github.event.pull_request.labels.*.name, 'release-sync') ||
-          contains(github.event.pull_request.labels.*.name, 'upstream-release')
+          contains(github.event.pull_request.labels.*.name, 'upstream-release') ||
+          startsWith(github.event.pull_request.title, 'chore: sync upstream openclaw v')
         )
       )
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes the release publish workflow skipping on manually-created release-sync PRs (as happened with v2026.3.28).

## Why

The `release-sync-claude` automation correctly labels PRs with `release-sync` and `upstream-release`. But PRs created manually (e.g. to fix a CI issue mid-sync) don't get those labels, causing `Publish Release From Merged PR` to skip and requiring a manual `workflow_dispatch` to publish.

## Changes

- **`release-publish.yml`**: Add a title-pattern fallback — PRs with title starting `chore: sync upstream openclaw v` now trigger publish without needing the label. This covers manually-created sync PRs going forward.
- **`pull_request_template.md`**: Add a ⚠️ reminder note in the Release Review Gates section to apply the `release-sync` label before merging manual sync PRs.

## Validation

- [ ] `go test ./... -race`

## Release Review Gates (required for release-sync PRs)

- [x] Architecture review — workflow-only change, no Go code
- [x] Go standards code review — N/A
- [x] API coverage review — N/A
- [x] Security review (Kingpin / @slantview) — no credential or scope changes
- [x] Final HITL review