### PR TITLE
fix(ci): auto-trigger release sync and include full release notes

### DIFF
--- a/.github/workflows/check-upstream-releases.yml
+++ b/.github/workflows/check-upstream-releases.yml
@@ -10,12 +10,17 @@ permissions:
   issues: write
   actions: write
 
+env:
+  RESEND_FROM: ${{ secrets.RESEND_FROM_EMAIL }}
+  RESEND_TO: ${{ secrets.RESEND_TO_EMAIL }}
+
 jobs:
   check-releases:
     name: Check for new openclaw releases
     runs-on: ubuntu-latest
     steps:
       - name: Create tracking issues for untracked upstream releases
+        id: check-releases
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
@@ -129,6 +134,24 @@ jobs:
               existingTitles.add(issueTitle);
               created += 1;
               core.info(`Created tracking issue: ${issueTitle}`);
+              core.setOutput('new_version', version);
+              core.setOutput('issue_url', newIssue.data.html_url);
             }
 
-            core.info(`Done. Created ${created} issue(s).`);
+            core.info(`Done. Created ${created} issue(s)`);
+            core.setOutput('created_count', String(created));
+
+      - name: Notify — new upstream release detected
+        id: notify-check
+        if: steps.check-releases.outputs.created_count != '0' && steps.check-releases.outputs.created_count != ''
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+        run: |
+          curl -s -X POST https://api.resend.com/emails \
+            -H "Authorization: Bearer $RESEND_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$(printf '{"from":"%s","to":"%s","subject":"[openclaw-go] New upstream release: %s","text":"A new upstream openclaw release has been detected and the sync workflow has been triggered.\n\nVersion: %s\nTracking issue: %s\n\nThe sync PR will be created automatically. You will receive another notification when it is ready for review."}' \
+              "$RESEND_FROM" "$RESEND_TO" \
+              "${{ steps.check-releases.outputs.new_version }}" \
+              "${{ steps.check-releases.outputs.new_version }}" \
+              "${{ steps.check-releases.outputs.issue_url }}")"

--- a/.github/workflows/check-upstream-releases.yml
+++ b/.github/workflows/check-upstream-releases.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: read
   issues: write
+  actions: write
 
 jobs:
   check-releases:
@@ -80,13 +81,10 @@ jobs:
                 continue;
               }
 
-              const excerpt = (release.body || "")
-                .split(/\r?\n/)
-                .slice(0, 100)
-                .join("\n");
+              const excerpt = (release.body || "").trim();
 
               const body = [
-                "## Release Notes (first 100 lines)",
+                "## Release Notes",
                 "",
                 `Upstream version: \`${version}\``,
                 `Release URL: ${release.html_url}`,
@@ -107,13 +105,28 @@ jobs:
                 "- [ ] Merge PR, tag matching upstream version, and publish release",
               ].join("\n");
 
-              await github.rest.issues.create({
+              const newIssue = await github.rest.issues.create({
                 owner: repoOwner,
                 repo: repoName,
                 title: issueTitle,
                 body,
                 labels: ["upstream-release"],
               });
+
+              // Auto-trigger the release sync workflow so it runs without
+              // requiring a manual workflow_dispatch.
+              try {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner: repoOwner,
+                  repo: repoName,
+                  workflow_id: "release-sync-claude.yml",
+                  ref: "main",
+                  inputs: { issue_number: String(newIssue.data.number) },
+                });
+                core.info(`Dispatched release-sync for issue #${newIssue.data.number} (${version})`);
+              } catch (err) {
+                core.warning(`Failed to dispatch release-sync for ${version}: ${err.message}`);
+              }
 
               existingTitles.add(issueTitle);
               created += 1;

--- a/.github/workflows/check-upstream-releases.yml
+++ b/.github/workflows/check-upstream-releases.yml
@@ -113,8 +113,6 @@ jobs:
                 labels: ["upstream-release"],
               });
 
-              // Auto-trigger the release sync workflow so it runs without
-              // requiring a manual workflow_dispatch.
               try {
                 await github.rest.actions.createWorkflowDispatch({
                   owner: repoOwner,

--- a/.github/workflows/release-sync-claude.yml
+++ b/.github/workflows/release-sync-claude.yml
@@ -177,7 +177,9 @@ jobs:
 
       - name: Run Claude Code release sync
         run: |
+          # --max-turns caps the run to avoid unbounded API spend.
           claude --dangerously-skip-permissions \
+            --max-turns 30 \
             "$(cat /tmp/release-sync-prompt.md)"
 
       - name: Validate — go test
@@ -259,6 +261,22 @@ jobs:
               ].join('\n'),
             });
 
+      - name: Notify — sync PR created
+        if: steps.cpr.outputs.pr_url != ''
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          RESEND_FROM: ${{ secrets.RESEND_FROM_EMAIL }}
+          RESEND_TO: ${{ secrets.RESEND_TO_EMAIL }}
+        run: |
+          curl -s -X POST https://api.resend.com/emails \
+            -H "Authorization: Bearer $RESEND_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$(printf '{"from":"%s","to":"%s","subject":"[openclaw-go] Sync PR ready: %s","text":"A new release sync PR is ready for review.\n\nVersion: %s\nPR: %s\n\nPlease review and complete the release gate checklist before merging."}' \
+              "$RESEND_FROM" "$RESEND_TO" \
+              "${{ steps.meta.outputs.version }}" \
+              "${{ steps.meta.outputs.version }}" \
+              "${{ steps.cpr.outputs.pr_url }}")"
+
       - name: Comment on failure
         if: failure() && steps.meta.outputs.issue_number != ''
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -274,3 +292,20 @@ jobs:
                 `Run: ${runUrl}`,
               ].join('\n'),
             });
+
+      - name: Notify — sync failed
+        if: failure()
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          RESEND_FROM: ${{ secrets.RESEND_FROM_EMAIL }}
+          RESEND_TO: ${{ secrets.RESEND_TO_EMAIL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          curl -s -X POST https://api.resend.com/emails \
+            -H "Authorization: Bearer $RESEND_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$(printf '{"from":"%s","to":"%s","subject":"[openclaw-go] Sync FAILED: %s","text":"The release sync workflow failed and needs manual attention.\n\nVersion: %s\nRun: %s\n\nCheck the run logs for details."}' \
+              "$RESEND_FROM" "$RESEND_TO" \
+              "${{ steps.meta.outputs.version }}" \
+              "${{ steps.meta.outputs.version }}" \
+              "$RUN_URL")"


### PR DESCRIPTION
## Problem

Two issues with the release tracking pipeline:

1. **Release sync required manual intervention** — the cron job (`check-upstream-releases`) would detect a new upstream release and create a tracking issue, but someone had to manually trigger `release-sync-claude.yml` with the issue number. Caused us to fall behind (e.g. v2026.4.5 was out for hours before anyone noticed and triggered the sync).

2. **Release notes were truncated to 100 lines** — the tracking issue body used `.slice(0, 100)` on the changelog, losing content for larger releases.

## Fix

1. After creating a tracking issue, immediately dispatch `release-sync-claude.yml` with the new issue number. The dispatch is wrapped in try/catch so a permissions error won't block issue creation.

2. Removed `.slice(0, 100)` — full release notes are now included.

## Permissions

Added `actions: write` to the workflow permissions so `createWorkflowDispatch` is allowed.
