### PR TITLE
feat(gateway): add missing methods from v2026.4.7-v2026.4.14 syncs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `CommandsList(ctx, CommandsListParams) (*CommandsListResult, error)` and `MessageAction(ctx, MessageActionParams) (json.RawMessage, error)` gateway methods
 - `ChannelsStart(ctx, ChannelsStartParams) (*ChannelsStartResult, error)` — starts a channel account (`channels.start`)
 - `ChannelsStartParams`, `ChannelsStartResult` protocol types
 - `MethodChannelsStart` method name constant


### PR DESCRIPTION
Adds 8 methods that were accumulated across sync PRs but not properly landed on main.