### PR TITLE
fix(drift): exclude scope-only HTTP methods from RPC parity failure gate

### DIFF
--- a/.github/workflows/release-sync-claude.yml
+++ b/.github/workflows/release-sync-claude.yml
@@ -203,9 +203,9 @@ jobs:
             --upstream-root /tmp/openclaw \
             --go-root . \
             --output /tmp/drift.json
-          MISSING=$(python3 -c "import json; d=json.load(open('/tmp/drift.json')); print(len(d['missing_in_go']))")
+          MISSING=$(python3 -c "import json; d=json.load(open('/tmp/drift.json')); print(len(d.get('missing_in_go_rpc', d['missing_in_go'])))")
           if [ "$MISSING" -gt 0 ]; then
-            echo "::error::Sync is incomplete — $MISSING methods still missing. Claude Code did not finish."
+            echo "::error::Sync is incomplete — $MISSING RPC methods still missing. Claude Code did not finish."
             exit 1
           fi
           echo "Drift check passed — no missing methods."

--- a/.github/workflows/upstream-api-drift-report.yml
+++ b/.github/workflows/upstream-api-drift-report.yml
@@ -38,6 +38,7 @@ jobs:
             const labels = ['release-sync'];
 
             const missing = report.missing_in_go || [];
+            const missingRpc = report.missing_in_go_rpc || missing;
             const extra = report.extra_in_go || [];
             const missingDetails = report.missing_details || [];
             const extraDetails = report.extra_details || [];
@@ -50,14 +51,15 @@ jobs:
               '',
               `- Upstream methods: **${report.upstream_method_count}**`,
               `- openclaw-go methods: **${report.go_method_count}**`,
-              `- Missing in openclaw-go: **${missing.length}**`,
+              `- Missing RPC methods in openclaw-go: **${missingRpc.length}**`,
+              `- Missing total including scope-only endpoints: **${missing.length}**`,
               `- Extra in openclaw-go: **${extra.length}**`,
               `- Upstream methods not in BASE_METHODS (compat/internal): **${listOnly.length + scopeOnly.length}**`,
               `- openclaw-go methods in upstream compat/internal set: **${goNotInBase.length}**`,
               '',
               '### Missing methods',
               ...(missingDetails.length
-                ? missingDetails.map((item) => `- \`${item.method}\` (upstream: \`${item.upstream_source}\`)`)
+                ? missingDetails.map((item) => `- \`${item.method}\` (upstream: \`${item.upstream_source}\`${item.scope_only ? ', scope-only' : ''})`)
                 : ['- none']),
               '',
               '### Extra methods',

--- a/scripts/upstream_drift_report.py
+++ b/scripts/upstream_drift_report.py
@@ -135,15 +135,25 @@ def main() -> int:
     go_methods, go_sources = collect_go_methods(go_root)
 
     missing = sorted(upstream_methods - go_methods)
+    # Scope-only methods are HTTP endpoints authorized via method-scopes.ts but
+    # not callable as RPC methods — the Go client does not need WebSocket stubs
+    # for them. Keep them visible in the report, but exclude them from the
+    # failure gate used by release-sync CI.
+    missing_rpc = sorted(set(missing) - scope_only_methods)
     extra = sorted(go_methods - upstream_methods)
 
     report = {
         "upstream_method_count": len(upstream_methods),
         "go_method_count": len(go_methods),
         "missing_in_go": missing,
+        "missing_in_go_rpc": missing_rpc,
         "extra_in_go": extra,
         "missing_details": [
-            {"method": m, "upstream_source": upstream_sources.get(m, "")}
+            {
+                "method": m,
+                "upstream_source": upstream_sources.get(m, ""),
+                "scope_only": m in scope_only_methods,
+            }
             for m in missing
         ],
         "extra_details": [
@@ -161,7 +171,7 @@ def main() -> int:
     else:
         print(encoded)
 
-    if missing and not args.allow_missing:
+    if missing_rpc and not args.allow_missing:
         return 2
     return 0
 


### PR DESCRIPTION
## Problem

The release-sync CI for v2026.4.21 failed because `assistant.media.get` was counted as a missing RPC method. It's not — it's an HTTP endpoint (`/__openclaw__/assistant-media`) that happens to appear in `method-scopes.ts` for authorization checks, but has no WebSocket RPC handler.

The drift script already correctly classifies it in `upstream_methods_scope_only` but was still including it in the `missing_in_go` count that gates CI failure.

Identified in #79 (2026-04-21 addendum).

## Changes

- **`scripts/upstream_drift_report.py`**: Add `missing_in_go_rpc` field (`missing - scope_only_methods`) to the report. Add `scope_only` flag per entry in `missing_details` for visibility. `missing_in_go` still present for full audit trail.
- **`.github/workflows/release-sync-claude.yml`**: CI failure gate now reads `missing_in_go_rpc` (falls back to `missing_in_go` for old reports).

## Result

Release-sync CI will no longer fail on scope-only HTTP methods. The v2026.4.21 sync can be re-run once this lands.