### PR TITLE
feat(identity): add NewIdentityFromSeed for non-disk persistence

### DIFF
--- a/identity/store.go
+++ b/identity/store.go
@@ -96,6 +96,40 @@ func (id *Identity) BuildDeviceIdentity(p SigningParams) *DeviceIdentityProto {
 	}
 }
 
+// NewIdentityFromSeed reconstructs an Identity from a previously persisted
+// Ed25519 private-key seed. It is intended for embedders that store the
+// keypair outside the filesystem (for example, in an OS-level secure
+// enclave or keystore) and need to hand the in-memory Identity to the
+// gateway client without touching disk.
+//
+// seed must be exactly ed25519.SeedSize (32) bytes. The deviceID is
+// re-derived from the public key (SHA-256(pub) hex), matching the on-disk
+// format produced by Store.LoadOrGenerate, so callers can pass any
+// non-empty value or "" to accept the derived ID.
+func NewIdentityFromSeed(seed []byte) (*Identity, error) {
+	if len(seed) != ed25519.SeedSize {
+		return nil, fmt.Errorf("identity: seed must be %d bytes, got %d", ed25519.SeedSize, len(seed))
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+	h := sha256.Sum256(pub)
+	return &Identity{
+		DeviceID:        fmt.Sprintf("%x", h[:]),
+		PublicKeyB64URL: base64.RawURLEncoding.EncodeToString(pub),
+		privateKey:      priv,
+	}, nil
+}
+
+// Seed returns the Ed25519 private-key seed (32 bytes) so embedders can
+// persist it in their own keystore. The returned slice is a copy; callers
+// should zero it after use.
+func (id *Identity) Seed() []byte {
+	seed := id.privateKey.Seed()
+	out := make([]byte, len(seed))
+	copy(out, seed)
+	return out
+}
+
 // LoadOrGenerate loads the device keypair from disk, generating one if absent.
 func (s *Store) LoadOrGenerate() (*Identity, error) {
 	id, err := s.load()

--- a/identity/store_test.go
+++ b/identity/store_test.go
@@ -74,6 +74,76 @@ func TestBuildDeviceIdentity_V2Payload_SignatureVerifies(t *testing.T) {
 	}
 }
 
+func TestNewIdentityFromSeed_MatchesStoreLoadOrGenerate(t *testing.T) {
+	// Generate via Store, capture the seed, reconstruct via NewIdentityFromSeed,
+	// and confirm the resulting Identity signs identically.
+	tmp := t.TempDir()
+	s, err := NewStore(tmp)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	original, err := s.LoadOrGenerate()
+	if err != nil {
+		t.Fatalf("LoadOrGenerate: %v", err)
+	}
+
+	seed := original.Seed()
+	if len(seed) != ed25519.SeedSize {
+		t.Fatalf("Seed len = %d, want %d", len(seed), ed25519.SeedSize)
+	}
+
+	rebuilt, err := NewIdentityFromSeed(seed)
+	if err != nil {
+		t.Fatalf("NewIdentityFromSeed: %v", err)
+	}
+	if rebuilt.DeviceID != original.DeviceID {
+		t.Fatalf("DeviceID = %q, want %q", rebuilt.DeviceID, original.DeviceID)
+	}
+	if rebuilt.PublicKeyB64URL != original.PublicKeyB64URL {
+		t.Fatalf("PublicKeyB64URL = %q, want %q", rebuilt.PublicKeyB64URL, original.PublicKeyB64URL)
+	}
+
+	p := SigningParams{
+		ClientID:   "gateway-client",
+		ClientMode: "backend",
+		Role:       "operator",
+		Scopes:     []string{"operator.read"},
+		Token:      "tok",
+		Nonce:      "nonce",
+	}
+	a := original.BuildDeviceIdentity(p)
+	b := rebuilt.BuildDeviceIdentity(p)
+	if a.ID != b.ID || a.PublicKey != b.PublicKey {
+		t.Fatalf("rebuilt identity diverges from original: %+v vs %+v", a, b)
+	}
+}
+
+func TestNewIdentityFromSeed_RejectsWrongLength(t *testing.T) {
+	if _, err := NewIdentityFromSeed(make([]byte, 16)); err == nil {
+		t.Fatal("expected error for short seed")
+	}
+	if _, err := NewIdentityFromSeed(nil); err == nil {
+		t.Fatal("expected error for nil seed")
+	}
+}
+
+func TestIdentitySeed_ReturnsCopy(t *testing.T) {
+	seed := make([]byte, ed25519.SeedSize)
+	for i := range seed {
+		seed[i] = byte(i)
+	}
+	id, err := NewIdentityFromSeed(seed)
+	if err != nil {
+		t.Fatalf("NewIdentityFromSeed: %v", err)
+	}
+	got := id.Seed()
+	got[0] ^= 0xff
+	again := id.Seed()
+	if again[0] == got[0] {
+		t.Fatalf("Seed() returned shared slice; mutation leaked back")
+	}
+}
+
 func TestStoreLoadOrGenerate_MigratesTruncatedDeviceID(t *testing.T) {
 	tmp := t.TempDir()
 	s, err := NewStore(tmp)


### PR DESCRIPTION
Hi A3T team - thank you for creating this library. It's super comprehensive.

Here's a contribution that adds a (tested) route for creating a new identity, but from bytes directly. Comments/suggestions are welcome.

## Summary

- Add `identity.NewIdentityFromSeed(seed []byte) (*Identity, error)` constructor that reconstructs an `Identity` from a previously persisted Ed25519 seed.
- Add `(*Identity).Seed() []byte` accessor that returns a defensive copy of the 32-byte seed for embedders to persist in their own keystore.
- DeviceID is re-derived from the public key via SHA-256 hex, matching the on-disk format produced by `Store.LoadOrGenerate`, so the in-memory and on-disk representations are interchangeable.

## Why

- The current `Store` ties keypair persistence to the local filesystem. Embedders that need to keep the device key in an OS-level secure store (e.g. an Apple Keychain, an Android Keystore, or an HSM) currently have to round-trip the private key through a temporary file before handing it to `gateway.WithIdentity`, which weakens the security guarantees that motivated using the secure store in the first place.
- These two additions let such embedders hydrate the `Identity` directly from raw bytes without touching disk, while leaving the existing `Store` API and on-disk layout untouched. Existing callers are unaffected.

## Validation

- [x] `go test ./... -race`
- New tests in `identity/store_test.go`:
  - `TestNewIdentityFromSeed_MatchesStoreLoadOrGenerate` — round-trips an `Identity` through `Store` ↔ seed and asserts the device ID, public key and signed payloads match.
  - `TestNewIdentityFromSeed_RejectsWrongLength` — guards the seed-length precondition.
  - `TestIdentitySeed_ReturnsCopy` — ensures `Seed()` does not expose the underlying slice.

## Notes

- `NewIdentityFromSeed` is the minimal surface needed; if you'd prefer a different name or a `Store`-method form (e.g. `Store.Hydrate(seed)`) I'm happy to rework. I picked a top-level constructor because the use case is explicitly *not* tied to a `Store`.