### PR TITLE
feat(gateway): add assistant.media.get method

### DIFF
--- a/gateway/assistant.go
+++ b/gateway/assistant.go
@@ -1,0 +1,16 @@
+package gateway
+
+import (
+	"context"
+
+	"github.com/a3tai/openclaw-go/protocol"
+)
+
+// AssistantMediaGet retrieves the current assistant media.
+func (c *Client) AssistantMediaGet(ctx context.Context) (*protocol.AssistantMediaGetResult, error) {
+	var result protocol.AssistantMediaGetResult
+	if err := c.sendRPCTyped(ctx, string(protocol.MethodAssistantMediaGet), struct{}{}, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -166,6 +166,9 @@ type MethodName string
 
 // Known RPC method name constants.
 const (
+	// Assistant media.
+	MethodAssistantMediaGet MethodName = "assistant.media.get"
+
 	// Agent identity and lifecycle.
 	MethodAgentIdentityGet MethodName = "agent.identity.get"
 	MethodAgentWait        MethodName = "agent.wait"
@@ -2433,6 +2436,12 @@ type SecretsResolveResult struct {
 	Assignments      []SecretsResolveAssignment `json:"assignments,omitempty"`
 	Diagnostics      []string                   `json:"diagnostics,omitempty"`
 	InactiveRefPaths []string                   `json:"inactiveRefPaths,omitempty"`
+}
+
+// AssistantMediaGetResult is the result of assistant.media.get.
+type AssistantMediaGetResult struct {
+	MediaURL  string   `json:"mediaUrl,omitempty"`
+	MediaURLs []string `json:"mediaUrls,omitempty"`
 }
 
 // GatewayIdentityResult is the result for "gateway.identity.get".


### PR DESCRIPTION
Fixes upstream API parity check failure on PRs #102, #105, and #111.

Adds missing `assistant.media.get` method that was detected as missing by the drift report.

Changes:
- Added `MethodAssistantMediaGet` constant to `protocol/protocol.go`
- Added `AssistantMediaGetResult` type to `protocol/protocol.go`
- Created `gateway/assistant.go` with `AssistantMediaGet` client method