### PR TITLE
feat(protocol): advertise v3–v4 range to support v4 gateways

### DIFF
--- a/gateway/client.go
+++ b/gateway/client.go
@@ -227,7 +227,7 @@ func (c *Client) readChallenge(ctx context.Context) (*protocol.ConnectChallenge,
 
 func (c *Client) buildConnectParams(challenge *protocol.ConnectChallenge) protocol.ConnectParams {
 	params := protocol.ConnectParams{
-		MinProtocol: protocol.ProtocolVersion,
+		MinProtocol: protocol.MinProtocolVersion,
 		MaxProtocol: protocol.ProtocolVersion,
 		Client:      c.opts.clientInfo,
 		Role:        c.opts.role,

--- a/gateway/client_test.go
+++ b/gateway/client_test.go
@@ -224,8 +224,11 @@ func TestConnect(t *testing.T) {
 	if hello.Protocol != protocol.ProtocolVersion {
 		t.Errorf("protocol = %d, want %d", hello.Protocol, protocol.ProtocolVersion)
 	}
-	if gotParams.MinProtocol != protocol.ProtocolVersion {
-		t.Errorf("minProtocol = %d, want %d", gotParams.MinProtocol, protocol.ProtocolVersion)
+	if gotParams.MinProtocol != protocol.MinProtocolVersion {
+		t.Errorf("minProtocol = %d, want %d", gotParams.MinProtocol, protocol.MinProtocolVersion)
+	}
+	if gotParams.MaxProtocol != protocol.ProtocolVersion {
+		t.Errorf("maxProtocol = %d, want %d", gotParams.MaxProtocol, protocol.ProtocolVersion)
 	}
 	if gotParams.Role != protocol.RoleOperator {
 		t.Errorf("role = %q, want %q", gotParams.Role, protocol.RoleOperator)

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -5,8 +5,18 @@ package protocol
 
 import "encoding/json"
 
-// ProtocolVersion is the current protocol version.
-const ProtocolVersion = 3
+// ProtocolVersion is the current/preferred protocol version emitted by
+// this client. The gateway negotiates the highest version both sides
+// support that falls within the advertised [MinProtocolVersion,
+// ProtocolVersion] range.
+const ProtocolVersion = 4
+
+// MinProtocolVersion is the oldest gateway protocol this client still
+// understands. Connect advertises minProtocol=MinProtocolVersion and
+// maxProtocol=ProtocolVersion so a single build pairs with both legacy
+// (v3) and current (v4) gateways. Gateways accept a client whose range
+// straddles their PROTOCOL_VERSION (minProtocol <= server <= maxProtocol).
+const MinProtocolVersion = 3
 
 // ---------------------------------------------------------------------------
 // Server Constants

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -643,8 +643,14 @@ func TestErrorPayloadFull(t *testing.T) {
 }
 
 func TestProtocolVersionConst(t *testing.T) {
-	if ProtocolVersion != 3 {
-		t.Errorf("ProtocolVersion = %d, want 3", ProtocolVersion)
+	if ProtocolVersion != 4 {
+		t.Errorf("ProtocolVersion = %d, want 4", ProtocolVersion)
+	}
+	if MinProtocolVersion != 3 {
+		t.Errorf("MinProtocolVersion = %d, want 3", MinProtocolVersion)
+	}
+	if MinProtocolVersion > ProtocolVersion {
+		t.Errorf("MinProtocolVersion %d must not exceed ProtocolVersion %d", MinProtocolVersion, ProtocolVersion)
 	}
 }
 


### PR DESCRIPTION
Advertise a protocol compatibility range so a single client build connects to both v3 and v4 OpenClaw gateways.

## Summary

- Add `MinProtocolVersion = 3` and bump `ProtocolVersion` to `4` in `protocol`.
- `buildConnectParams` now advertises `minProtocol=MinProtocolVersion(3)`, `maxProtocol=ProtocolVersion(4)` instead of pinning `min=max` to a single version.
- Update the affected protocol/gateway unit tests for the new range.

## Why

- OpenClaw gateways >= 2026.5.x run gateway protocol **v4** and reject any client that pins `minProtocol=maxProtocol=3`, failing the handshake with `INVALID_REQUEST: protocol mismatch`. The SDK currently pins v3, so clients can no longer connect to current gateways.
- The gateway accepts a client whose advertised range straddles its `PROTOCOL_VERSION` (`minProtocol <= server <= maxProtocol`). Advertising `[3, 4]` lets one build negotiate with both legacy v3 and current v4 gateways.
- Verified against a live openclaw 2026.5.28 gateway: the handshake now negotiates v4 and the "protocol mismatch" rejection is gone. v4's chat frames remain wire-compatible (the `state` field and full `message` snapshot are still sent; the new `deltaText`/`replace` fields are additive).

## Validation

- [x] `go test ./... -race`

## Notes

- Backward compatible: the advertised floor of 3 means existing v3 gateways still negotiate v3.