### PR TITLE
feat(gateway): support setup-code bootstrap token at connect

### DIFF
--- a/gateway/client.go
+++ b/gateway/client.go
@@ -239,11 +239,16 @@ func (c *Client) buildConnectParams(challenge *protocol.ConnectChallenge) protoc
 		UserAgent:   c.opts.userAgent,
 	}
 
-	// Auth: token or password.
+	// Auth: token or password, plus an optional bootstrap token. The
+	// bootstrap token rides alongside the device identity on first connect
+	// and may be presented with or without a shared token/password.
 	if c.opts.token != "" {
-		params.Auth = protocol.AuthParams{Token: c.opts.token}
+		params.Auth.Token = c.opts.token
 	} else if c.opts.password != "" {
-		params.Auth = protocol.AuthParams{Password: c.opts.password}
+		params.Auth.Password = c.opts.password
+	}
+	if c.opts.bootstrapToken != "" {
+		params.Auth.BootstrapToken = c.opts.bootstrapToken
 	}
 
 	// Device identity (includes challenge nonce for signing).
@@ -258,12 +263,19 @@ func (c *Client) buildConnectParams(challenge *protocol.ConnectChallenge) protoc
 		for i, s := range c.opts.scopes {
 			scopeStrs[i] = string(s)
 		}
+		// The gateway verifies the signature against the token it resolves
+		// from the connect auth (token, then bootstrapToken). When only a
+		// bootstrap token is presented, sign over it so the signature matches.
+		signatureToken := c.opts.token
+		if signatureToken == "" {
+			signatureToken = c.opts.bootstrapToken
+		}
 		sp := identity.SigningParams{
 			ClientID:   c.opts.clientInfo.ID,
 			ClientMode: c.opts.clientInfo.Mode,
 			Role:       string(c.opts.role),
 			Scopes:     scopeStrs,
-			Token:      c.opts.token,
+			Token:      signatureToken,
 			Nonce:      nonce,
 		}
 		params.Device = c.opts.deviceSigner(sp)
@@ -282,36 +294,47 @@ func (c *Client) readHelloOK(ctx context.Context, reqID string) error {
 	_ = c.conn.SetReadDeadline(time.Now().Add(c.opts.connectTimeout))
 	defer func() { _ = c.conn.SetReadDeadline(time.Time{}) }()
 
-	_, msg, err := c.conn.ReadMessage()
-	if err != nil {
-		return err
-	}
-	var resp protocol.Response
-	if err := json.Unmarshal(msg, &resp); err != nil {
-		return fmt.Errorf("unmarshal response: %w", err)
-	}
-	if resp.ID != reqID {
-		return fmt.Errorf("response id mismatch: got %q, want %q", resp.ID, reqID)
-	}
-	if !resp.OK {
-		if resp.Error != nil {
-			return fmt.Errorf("connect rejected: %s: %s", resp.Error.Code, resp.Error.Message)
+	// The connect response is the frame whose id matches our request. Some
+	// connect flows (notably node-role connects) interleave event frames
+	// before hello-ok; events carry no response id, so skip any frame that
+	// is not the matching response rather than mistaking it for the reply.
+	for {
+		_, msg, err := c.conn.ReadMessage()
+		if err != nil {
+			return err
 		}
-		return errors.New("connect rejected (no error details)")
-	}
+		var resp protocol.Response
+		if err := json.Unmarshal(msg, &resp); err != nil {
+			return fmt.Errorf("unmarshal response: %w", err)
+		}
+		if resp.Type != protocol.FrameTypeResponse {
+			// Interstitial event or other non-response frame (some node-role
+			// connects emit one before hello-ok) — keep reading.
+			continue
+		}
+		if resp.ID != reqID {
+			return fmt.Errorf("response id mismatch: got %q, want %q", resp.ID, reqID)
+		}
+		if !resp.OK {
+			if resp.Error != nil {
+				return fmt.Errorf("connect rejected: %s: %s", resp.Error.Code, resp.Error.Message)
+			}
+			return errors.New("connect rejected (no error details)")
+		}
 
-	var hello protocol.HelloOK
-	if err := json.Unmarshal(resp.Payload, &hello); err != nil {
-		return fmt.Errorf("unmarshal hello-ok: %w", err)
-	}
-	c.hello = &hello
+		var hello protocol.HelloOK
+		if err := json.Unmarshal(resp.Payload, &hello); err != nil {
+			return fmt.Errorf("unmarshal hello-ok: %w", err)
+		}
+		c.hello = &hello
 
-	// Apply server-provided tick interval.
-	if hello.Policy.TickIntervalMs > 0 {
-		c.opts.tickInterval = time.Duration(hello.Policy.TickIntervalMs) * time.Millisecond
-	}
+		// Apply server-provided tick interval.
+		if hello.Policy.TickIntervalMs > 0 {
+			c.opts.tickInterval = time.Duration(hello.Policy.TickIntervalMs) * time.Millisecond
+		}
 
-	return nil
+		return nil
+	}
 }
 
 func (c *Client) readLoop() {

--- a/gateway/client_test.go
+++ b/gateway/client_test.go
@@ -263,6 +263,38 @@ func TestConnectWithPassword(t *testing.T) {
 	}
 }
 
+func TestConnectWithBootstrapToken(t *testing.T) {
+	var gotParams protocol.ConnectParams
+	mg, wsURL, cleanup := startMockGateway(t)
+	defer cleanup()
+
+	mg.onConnect = func(p protocol.ConnectParams) {
+		gotParams = p
+	}
+
+	client := NewClient(
+		WithBootstrapToken("setup-code-bootstrap"),
+		WithDevice(protocol.DeviceIdentity{ID: "dev-1", PublicKey: "pk", Signature: "sig", SignedAt: 1}),
+		WithConnectTimeout(5*time.Second),
+	)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := client.Connect(ctx, wsURL); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if gotParams.Auth.BootstrapToken != "setup-code-bootstrap" {
+		t.Errorf("auth.bootstrapToken = %q, want 'setup-code-bootstrap'", gotParams.Auth.BootstrapToken)
+	}
+	// A shared token may ride alongside the bootstrap token, but here none
+	// was set, so it must stay empty rather than be clobbered.
+	if gotParams.Auth.Token != "" {
+		t.Errorf("auth.token = %q, want empty", gotParams.Auth.Token)
+	}
+}
+
 // --- Connect with device identity ---
 
 func TestConnectWithDevice(t *testing.T) {

--- a/gateway/client_test.go
+++ b/gateway/client_test.go
@@ -283,7 +283,8 @@ func TestConnectWithBootstrapToken(t *testing.T) {
 	defer cancel()
 
 	if err := client.Connect(ctx, wsURL); err != nil {
-		t.Fatalf("Connect: %v", err)
+		t.Errorf("Connect: %v", err)
+		return
 	}
 	if gotParams.Auth.BootstrapToken != "setup-code-bootstrap" {
 		t.Errorf("auth.bootstrapToken = %q, want 'setup-code-bootstrap'", gotParams.Auth.BootstrapToken)

--- a/gateway/client_test.go
+++ b/gateway/client_test.go
@@ -2,7 +2,9 @@ package gateway
 
 import (
 	"context"
+	"crypto/ed25519"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -12,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/a3tai/openclaw-go/identity"
 	"github.com/a3tai/openclaw-go/protocol"
 	"github.com/gorilla/websocket"
 )
@@ -49,6 +52,10 @@ type mockGateway struct {
 
 	// sendMismatchedID causes the response to have a wrong ID.
 	sendMismatchedID bool
+
+	// sendInterstitialEvent emits an event frame just before hello-ok, as some
+	// node-role connect flows do.
+	sendInterstitialEvent bool
 }
 
 // waitReady blocks until the mock has entered its read loop.
@@ -154,6 +161,12 @@ func (m *mockGateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		raw := fmt.Sprintf(`{"type":"res","id":%q,"ok":true,"payload":"not an object"}`, req.ID)
 		conn.WriteMessage(websocket.TextMessage, []byte(raw))
 		return
+	}
+
+	// Optional interstitial event before hello-ok (node-role connect flows).
+	if m.sendInterstitialEvent {
+		evData, _ := protocol.MarshalEvent("node.interstitial", map[string]string{"k": "v"})
+		conn.WriteMessage(websocket.TextMessage, evData)
 	}
 
 	// 3. Send hello-ok response.
@@ -293,6 +306,92 @@ func TestConnectWithBootstrapToken(t *testing.T) {
 	// was set, so it must stay empty rather than be clobbered.
 	if gotParams.Auth.Token != "" {
 		t.Errorf("auth.token = %q, want empty", gotParams.Auth.Token)
+	}
+}
+
+// TestConnectBootstrapTokenSignedIntoDevice verifies that when only a bootstrap
+// token is presented (no shared/device token), the device identity signature is
+// computed over the bootstrap token — matching what the gateway resolves from
+// auth.bootstrapToken.
+func TestConnectBootstrapTokenSignedIntoDevice(t *testing.T) {
+	id, err := identity.NewIdentityFromSeed(make([]byte, ed25519.SeedSize))
+	if err != nil {
+		t.Errorf("NewIdentityFromSeed: %v", err)
+		return
+	}
+
+	var gotParams protocol.ConnectParams
+	mg, wsURL, cleanup := startMockGateway(t)
+	defer cleanup()
+	mg.onConnect = func(p protocol.ConnectParams) { gotParams = p }
+
+	const bootTok = "boot-tok"
+	clientInfo := protocol.ClientInfo{ID: protocol.ClientIDNodeHost, Version: "0.1.0", Platform: "go", Mode: protocol.ClientModeNode}
+	client := NewClient(
+		WithClientInfo(clientInfo),
+		WithRole(protocol.RoleNode),
+		WithScopes(protocol.ScopeOperatorRead),
+		WithBootstrapToken(bootTok),
+		WithIdentity(id, ""), // no device token: the bootstrap token must be signed over
+		WithConnectTimeout(5*time.Second),
+	)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Connect(ctx, wsURL); err != nil {
+		t.Errorf("Connect: %v", err)
+		return
+	}
+
+	dev := gotParams.Device
+	if dev == nil {
+		t.Error("device identity was not signed")
+		return
+	}
+	if gotParams.Auth.BootstrapToken != bootTok {
+		t.Errorf("auth.bootstrapToken = %q, want %q", gotParams.Auth.BootstrapToken, bootTok)
+	}
+
+	// The signature must verify over a v2 payload whose token field is the
+	// bootstrap token — proving the client signed over it, not an empty token.
+	payload := fmt.Sprintf("v2|%s|%s|%s|%s|%s|%d|%s|%s",
+		dev.ID, clientInfo.ID, clientInfo.Mode, string(protocol.RoleNode),
+		"operator.read", dev.SignedAt, bootTok, dev.Nonce)
+	pub, err := base64.RawURLEncoding.DecodeString(dev.PublicKey)
+	if err != nil {
+		t.Errorf("decode public key: %v", err)
+		return
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(dev.Signature)
+	if err != nil {
+		t.Errorf("decode signature: %v", err)
+		return
+	}
+	if !ed25519.Verify(ed25519.PublicKey(pub), []byte(payload), sig) {
+		t.Error("signature does not verify over a payload containing the bootstrap token")
+	}
+}
+
+// TestConnectSkipsInterstitialEvent verifies the handshake skips an event frame
+// sent before hello-ok (as node-role connects do) instead of mistaking it for
+// the connect response.
+func TestConnectSkipsInterstitialEvent(t *testing.T) {
+	mg, wsURL, cleanup := startMockGateway(t)
+	defer cleanup()
+	mg.sendInterstitialEvent = true
+
+	client := NewClient(WithToken("tok"), WithConnectTimeout(5*time.Second))
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Connect(ctx, wsURL); err != nil {
+		t.Errorf("Connect with interstitial event: %v", err)
+		return
+	}
+	if client.Hello() == nil {
+		t.Error("hello is nil after skipping interstitial event")
 	}
 }
 

--- a/gateway/options.go
+++ b/gateway/options.go
@@ -14,8 +14,9 @@ type Option func(*options)
 
 type options struct {
 	// Auth
-	token    string
-	password string
+	token          string
+	password       string
+	bootstrapToken string
 
 	// Client identity
 	clientInfo   protocol.ClientInfo
@@ -74,6 +75,15 @@ func WithToken(token string) Option {
 // WithPassword sets the password for authentication.
 func WithPassword(password string) Option {
 	return func(o *options) { o.password = password }
+}
+
+// WithBootstrapToken sets a short-lived setup-code bootstrap token (from
+// `openclaw qr`) presented in the connect auth alongside a device identity.
+// The gateway redeems it to establish and approve the device on first
+// connect, then issues a durable device token in hello-ok. A device
+// identity (WithIdentity) is required for the gateway to accept it.
+func WithBootstrapToken(token string) Option {
+	return func(o *options) { o.bootstrapToken = token }
 }
 
 // WithClientInfo overrides the default client identity.

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -466,6 +466,11 @@ type DeviceIdentity struct {
 type AuthParams struct {
 	Token    string `json:"token,omitempty"`
 	Password string `json:"password,omitempty"`
+	// BootstrapToken is a short-lived setup-code credential (from
+	// `openclaw qr`) presented alongside a device identity at connect. The
+	// gateway redeems it to establish and approve the device with the
+	// bootstrap scope profile, without a manual pairing approval.
+	BootstrapToken string `json:"bootstrapToken,omitempty"`
 }
 
 // ConnectParams is the params payload for a "connect" request.
@@ -527,6 +532,19 @@ type HelloAuth struct {
 	DeviceToken string   `json:"deviceToken"`
 	Role        string   `json:"role"`
 	Scopes      []string `json:"scopes"`
+	IssuedAtMs  *int64   `json:"issuedAtMs,omitempty"`
+	// DeviceTokens carries additional per-role device tokens minted during a
+	// setup-code bootstrap handoff — e.g. when connecting as a node, the
+	// bounded operator token is delivered here so the client can reconnect as
+	// an operator. Empty for ordinary connects.
+	DeviceTokens []HelloDeviceToken `json:"deviceTokens,omitempty"`
+}
+
+// HelloDeviceToken is a single per-role device token from a bootstrap handoff.
+type HelloDeviceToken struct {
+	DeviceToken string   `json:"deviceToken"`
+	Role        string   `json:"role"`
+	Scopes      []string `json:"scopes,omitempty"`
 	IssuedAtMs  *int64   `json:"issuedAtMs,omitempty"`
 }
 


### PR DESCRIPTION
Let SDK clients complete OpenClaw's setup-code (`openclaw qr`) onboarding: present a bootstrap token at connect and recover the bounded operator token from the gateway's node→operator handoff.

## Summary

- Add `AuthParams.BootstrapToken` (`auth.bootstrapToken`) and a `WithBootstrapToken(token)` option, signing over the bootstrap token as the gateway expects when no shared token is present.
- Add `HelloAuth.DeviceTokens` (`auth.deviceTokens`) so a node-role client can read the per-role handoff tokens the gateway returns after a silent setup-code approval — including the bounded operator token to reconnect with.
- Tolerate interstitial event frames before hello-ok (node-role connects emit one) instead of failing with a response-id mismatch.

## Why

- The gateway's `openclaw qr` flow issues a short-lived bootstrap token. A node client that presents it (with a device identity) is silently approved for the setup-code profile and handed bounded per-role device tokens in hello-ok. The Go SDK previously had no way to send the field, sign it correctly, or read the handoff tokens, so headless onboarding was impossible from Go.
- Validated end-to-end against a live openclaw 2026.5.28 gateway: node bootstrap → operator token handoff → operator reconnect.

## Validation

- [x] `go test ./... -race`