### PR TITLE
chore(release): sync v2026.4.14 from upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,15 @@ Sync to upstream openclaw v2026.4.15. Adds dream diary maintenance operations an
 - `ModelsAuthStatusResult`, `ModelsAuthStatusProvider`, `ModelsAuthStatusProfile`, `ModelsAuthExpiry` protocol types
 - `MethodDoctorMemoryRepairDreamingArtifacts`, `MethodDoctorMemoryDedupeDreamDiary`, `MethodModelsAuthStatus` method name constants
 
+## [v2026.4.14] - 2026-04-15
+
+Sync to upstream openclaw v2026.4.14. No net new SDK surface is required on current `main`; the current gateway/protocol surface already covers the upstream RPC set for this tag.
+
+### Changed
+
+- Added the v2026.4.14 release-sync specification and validation record.
+- Confirmed current typed gateway surfaces cover the v2026.4.14 upstream RPC set.
+
 ## [v2026.4.12] - 2026-04-14
 
 Sync to upstream openclaw v2026.4.12. No net new SDK surface is required on current `main`; methods introduced or tracked around this upstream release are already covered by accumulated release-train work.

--- a/docs/specs/v2026.4.14.md
+++ b/docs/specs/v2026.4.14.md
@@ -1,0 +1,43 @@
+# Upstream Sync Spec: v2026.4.14
+
+- Upstream release: https://github.com/openclaw/openclaw/releases/tag/v2026.4.14
+- Tracking issue: https://github.com/a3tai/openclaw-go/issues/93
+
+## Upstream Release Diff Evidence
+
+- Compare range: `v2026.4.12..v2026.4.14`
+- Upstream compare: https://github.com/openclaw/openclaw/compare/v2026.4.12...v2026.4.14
+
+### RPC method deltas
+
+Validation against the exact upstream tag reports no net RPC surface delta for `v2026.4.14` relative to `v2026.4.12`:
+
+- Added methods: **0**
+- Removed methods: **0**
+- Missing in Go SDK: **0**
+
+The upstream release is a broad quality/provider/channel release; current `main` already covers the gateway/protocol surface needed for this tag.
+
+## openclaw-go changes in this PR
+
+- Added this release-sync specification and validation record.
+- Updated `CHANGELOG.md` with the `v2026.4.14` release boundary.
+- No net new Go SDK surface is required on current `main`.
+
+## Required review gates
+
+- [x] Architecture review
+- [x] Go standards code review
+- [x] API coverage review
+- [x] Security review
+- [x] Final HITL review
+
+## Validation
+
+- [x] `git diff --check`
+- [x] `go test ./... -race`
+- [x] `python3 scripts/validate_release_sync.py --upstream-root /home/karunabot/work/openclaw-upstream-v2026.4.14 --go-root . --version v2026.4.14`
+- [x] `python3 scripts/upstream_drift_report.py --upstream-root /home/karunabot/work/openclaw-upstream-v2026.4.14 --go-root .`
+- [x] `go vet ./...`
+- [x] `go build ./...`
+- [x] `go build ./examples/...`


### PR DESCRIPTION
## Summary

Oldest-first release train catch-up for upstream openclaw `v2026.4.14`.

Current `main` already covers the gateway/protocol surface required for this tag, so this PR records the release boundary, spec, and validation evidence without reintroducing stale duplicate wrappers from the historical closed branch.

Closes #93.

## Validation

- [x] `git diff --check`
- [x] `go test ./... -race`
- [x] `python3 scripts/validate_release_sync.py --upstream-root /home/karunabot/work/openclaw-upstream-v2026.4.14 --go-root . --version v2026.4.14`
- [x] `python3 scripts/upstream_drift_report.py --upstream-root /home/karunabot/work/openclaw-upstream-v2026.4.14 --go-root .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go build ./examples/...`

## Release gates

- [x] Architecture review
- [x] Go standards code review
- [x] API coverage review
- [x] Security review
- [x] Final HITL review