### PR TITLE
chore(release): sync v2026.4.21 from upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `CronListParams.IncludeDisabled` — use `Enabled` field instead (`"all"`, `"enabled"`, `"disabled"`)
 
+## [v2026.4.21] - 2026-04-22
+
+Sync to upstream openclaw v2026.4.21. No net new SDK surface is required on current `main`; the current gateway/protocol surface already covers the upstream RPC set for this tag.
+
+### Changed
+
+- Added the v2026.4.21 release-sync specification and validation record.
+- Confirmed current typed gateway surfaces cover the v2026.4.21 upstream RPC set.
+
 ## [v2026.4.20] - 2026-04-22
 
 Sync to upstream openclaw v2026.4.20. Adds scoped assistant media retrieval; `channels.start` is already present on current `main`.

--- a/docs/specs/v2026.4.21.md
+++ b/docs/specs/v2026.4.21.md
@@ -1,0 +1,43 @@
+# Upstream Sync Spec: v2026.4.21
+
+- Upstream release: https://github.com/openclaw/openclaw/releases/tag/v2026.4.21
+- Tracking issue: https://github.com/a3tai/openclaw-go/issues/104
+
+## Upstream Release Diff Evidence
+
+- Compare range: `v2026.4.20..v2026.4.21`
+- Upstream compare: https://github.com/openclaw/openclaw/compare/v2026.4.20...v2026.4.21
+
+### RPC method deltas
+
+Validation against the exact upstream tag reports no net RPC surface delta for `v2026.4.21` relative to `v2026.4.20`:
+
+- Added methods: **0**
+- Removed methods: **0**
+- Missing in Go SDK: **0**
+
+The current Go SDK already covers the gateway/protocol surface needed for this tag.
+
+## openclaw-go changes in this PR
+
+- Added this release-sync specification and validation record.
+- Updated `CHANGELOG.md` with the `v2026.4.21` release boundary.
+- No net new Go SDK surface is required on current `main`.
+
+## Required review gates
+
+- [x] Architecture review
+- [x] Go standards code review
+- [x] API coverage review
+- [x] Security review (Kingpin / @slantview)
+- [x] Final HITL review
+
+## Validation
+
+- [x] `git diff --check`
+- [x] `go test ./... -race`
+- [x] `python3 scripts/validate_release_sync.py --upstream-root /home/karunabot/work/openclaw-upstream-v2026.4.21 --go-root . --version v2026.4.21`
+- [x] `python3 scripts/upstream_drift_report.py --upstream-root /home/karunabot/work/openclaw-upstream-v2026.4.21 --go-root .`
+- [x] `go vet ./...`
+- [x] `go build ./...`
+- [x] `go build ./examples/...`


### PR DESCRIPTION
## Summary

Oldest-first release train catch-up for upstream openclaw `v2026.4.21`.

Current `main` already covers the gateway/protocol surface required for this tag, so this PR records the release boundary, spec, and validation evidence.

Closes #104.

## Validation

- [x] `git diff --check`
- [x] `go test ./... -race`
- [x] `python3 scripts/validate_release_sync.py --upstream-root /home/karunabot/work/openclaw-upstream-v2026.4.21 --go-root . --version v2026.4.21`
- [x] `python3 scripts/upstream_drift_report.py --upstream-root /home/karunabot/work/openclaw-upstream-v2026.4.21 --go-root .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go build ./examples/...`

## Release gates

- [x] Architecture review
- [x] Go standards code review
- [x] API coverage review
- [x] Security review (Kingpin / @slantview)
- [x] Final HITL review
- [x] `go test ./... -race`